### PR TITLE
Add device removal support via UI

### DIFF
--- a/custom_components/odio_audio/__init__.py
+++ b/custom_components/odio_audio/__init__.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
@@ -207,6 +208,16 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, platforms):
         hass.data[DOMAIN].pop(entry.entry_id)
     return unload_ok
+
+
+async def async_remove_config_entry_device(
+    hass: HomeAssistant, config_entry: ConfigEntry, device_entry: DeviceEntry
+) -> bool:
+    """Remove a device from the integration.
+
+    Allow the user to remove the Receiver or Services device from the UI.
+    """
+    return True
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:


### PR DESCRIPTION
Implement async_remove_config_entry_device to allow users to delete Receiver or Services devices from the Home Assistant UI.

https://claude.ai/code/session_01WjarZUx55wkeZd3toaXMjQ