### PR TITLE
Make /audio/server endpoint optional in API validation

### DIFF
--- a/custom_components/odio_audio/__init__.py
+++ b/custom_components/odio_audio/__init__.py
@@ -86,7 +86,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         try:
             clients = await api.get_clients() if has_pulseaudio else []
             players = await api.get_players() if has_mpris else []
-            server = await api.get_server_info() if has_pulseaudio else {}
+            try:
+                server = await api.get_server_info() if has_pulseaudio else {}
+            except Exception:
+                _LOGGER.debug("Could not fetch /audio/server, skipping")
+                server = {}
             # Reset failure count on success
             failure_counts["audio"] = 0
             return {"audio": clients, "players": players, "server": server}


### PR DESCRIPTION
## Summary
This PR makes the `/audio/server` endpoint optional during API validation and data fetching. The endpoint is no longer treated as a critical requirement, allowing the integration to function even when the server info endpoint is unavailable.

## Key Changes
- **Config validation (`config_flow.py`)**: Moved `get_server_info()` call outside the critical validation path. The endpoint is now queried separately with exception handling, allowing validation to succeed even if it fails.
- **Remote client filtering (`config_flow.py`)**: Updated `async_fetch_remote_clients()` to gracefully handle missing server info. When the endpoint is unavailable, clients are no longer filtered by hostname.
- **Audio update loop (`__init__.py`)**: Added exception handling around `get_server_info()` in the periodic update function to prevent failures from interrupting the entire update cycle.
- **Filtering logic**: Updated client filtering to use `server_hostname is None or client.get("host") != server_hostname` to properly handle cases where server info is unavailable.

## Implementation Details
- Server info is now treated as optional metadata rather than a required API component
- Missing server info is logged at debug level and doesn't cause validation failures
- The integration will continue to function with reduced device details when `/audio/server` is unavailable
- All changes maintain backward compatibility with APIs that do provide server info

https://claude.ai/code/session_01FJzds6H3We374nnD1JK4dL