### PR TITLE
Update ZeroconfServiceInfo import path for Home Assistant compatibility

### DIFF
--- a/custom_components/odio_remote/config_flow.py
+++ b/custom_components/odio_remote/config_flow.py
@@ -8,7 +8,7 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,

--- a/custom_components/odio_remote/tests/test_config_flow.py
+++ b/custom_components/odio_remote/tests/test_config_flow.py
@@ -2,7 +2,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.components.zeroconf import ZeroconfServiceInfo
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.odio_remote.config_flow import (


### PR DESCRIPTION
## Summary
Updated the import path for `ZeroconfServiceInfo` to use the new Home Assistant helpers module structure, ensuring compatibility with recent Home Assistant versions.

## Key Changes
- Updated import in `custom_components/odio_remote/config_flow.py`:
  - Changed from: `homeassistant.components.zeroconf`
  - Changed to: `homeassistant.helpers.service_info.zeroconf`
- Updated import in `custom_components/odio_remote/tests/test_config_flow.py`:
  - Changed from: `homeassistant.components.zeroconf`
  - Changed to: `homeassistant.helpers.service_info.zeroconf`

## Details
This change reflects Home Assistant's refactoring of the zeroconf service info module from the components namespace to the helpers namespace. Both the main component and its tests have been updated to use the new import path, maintaining consistency across the codebase.

https://claude.ai/code/session_018mKdYiLZpq261QZPN9UgxR