### PR TITLE
Add switch platform to start/stop user-scope systemd services

### DIFF
--- a/custom_components/odio_remote/__init__.py
+++ b/custom_components/odio_remote/__init__.py
@@ -24,7 +24,11 @@ from .coordinator import OdioAudioCoordinator, OdioServiceCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[Platform] = [Platform.MEDIA_PLAYER, Platform.BUTTON]
+PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
+    Platform.MEDIA_PLAYER,
+    Platform.SWITCH,
+]
 
 
 @dataclass

--- a/custom_components/odio_remote/api_client.py
+++ b/custom_components/odio_remote/api_client.py
@@ -156,17 +156,21 @@ class OdioApiClient:
         scope: str,
         unit: str,
     ) -> None:
-        """Control systemd service (enable/disable/restart)."""
+        """Control systemd service (enable/disable/restart/start/stop)."""
         from .const import (
-            ENDPOINT_SERVICE_ENABLE,
             ENDPOINT_SERVICE_DISABLE,
+            ENDPOINT_SERVICE_ENABLE,
             ENDPOINT_SERVICE_RESTART,
+            ENDPOINT_SERVICE_START,
+            ENDPOINT_SERVICE_STOP,
         )
 
         endpoint_map = {
             "enable": ENDPOINT_SERVICE_ENABLE,
             "disable": ENDPOINT_SERVICE_DISABLE,
             "restart": ENDPOINT_SERVICE_RESTART,
+            "start": ENDPOINT_SERVICE_START,
+            "stop": ENDPOINT_SERVICE_STOP,
         }
 
         endpoint_template = endpoint_map.get(action)

--- a/custom_components/odio_remote/const.py
+++ b/custom_components/odio_remote/const.py
@@ -29,6 +29,8 @@ ENDPOINT_SERVICE_RESTART: Final = "/services/{scope}/{unit}/restart"
 ENDPOINT_POWER: Final = "/power"
 ENDPOINT_POWER_OFF: Final = "/power/power_off"
 ENDPOINT_POWER_REBOOT: Final = "/power/reboot"
+ENDPOINT_SERVICE_START: Final = "/services/{scope}/{unit}/start"
+ENDPOINT_SERVICE_STOP: Final = "/services/{scope}/{unit}/stop"
 
 # Attributes
 ATTR_CLIENT_ID: Final = "client_id"

--- a/custom_components/odio_remote/switch.py
+++ b/custom_components/odio_remote/switch.py
@@ -1,0 +1,110 @@
+"""Switch platform for Odio Remote — start/stop user-scope systemd services."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import OdioConfigEntry
+from .api_client import OdioApiClient
+from .const import DOMAIN
+from .coordinator import OdioServiceCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: OdioConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Odio Remote switch entities."""
+    runtime_data = entry.runtime_data
+    service_coordinator = runtime_data.service_coordinator
+
+    if service_coordinator is None or not service_coordinator.data:
+        return
+
+    server_hostname = runtime_data.server_info.get("hostname", entry.entry_id)
+    services = service_coordinator.data.get("services", [])
+
+    entities = [
+        OdioServiceSwitch(
+            service_coordinator,
+            runtime_data.api,
+            entry.entry_id,
+            svc,
+            server_hostname,
+        )
+        for svc in services
+        if svc.get("exists") and svc.get("scope") == "user"
+    ]
+
+    _LOGGER.debug("Creating %d service switch entities", len(entities))
+    async_add_entities(entities)
+
+
+class OdioServiceSwitch(CoordinatorEntity[OdioServiceCoordinator], SwitchEntity):
+    """Switch that starts/stops a user-scope systemd service."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: OdioServiceCoordinator,
+        api: OdioApiClient,
+        entry_id: str,
+        service_info: dict[str, Any],
+        server_hostname: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._api = api
+        self._service_info = service_info
+
+        service_name: str = service_info["name"]
+        scope: str = service_info["scope"]
+
+        self._attr_unique_id = f"{entry_id}_switch_{scope}_{service_name}"
+        self._attr_name = service_name.removesuffix(".service")
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry_id)},
+            name=f"Odio Remote ({server_hostname})",
+            manufacturer="Odio",
+        )
+
+    @property
+    def is_on(self) -> bool:
+        """Return True when the service is running."""
+        if not self.coordinator.data:
+            return False
+        for svc in self.coordinator.data.get("services", []):
+            if svc["name"] == self._service_info["name"] and svc["scope"] == self._service_info["scope"]:
+                return svc.get("running", False)
+        return False
+
+    @property
+    def available(self) -> bool:
+        """Return False when the coordinator has no data."""
+        return self.coordinator.last_update_success and bool(self.coordinator.data)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Start the service."""
+        await self._api.control_service(
+            "start", self._service_info["scope"], self._service_info["name"]
+        )
+        await asyncio.sleep(2)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Stop the service."""
+        await self._api.control_service(
+            "stop", self._service_info["scope"], self._service_info["name"]
+        )
+        await asyncio.sleep(2)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/odio_remote/tests/test_api_client.py
+++ b/custom_components/odio_remote/tests/test_api_client.py
@@ -434,6 +434,38 @@ class TestOdioApiClientServiceControl:
                 assert len(m.requests) == 1
 
     @pytest.mark.asyncio
+    async def test_control_service_start(self):
+        """Test control_service start."""
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with aioresponses() as m:
+                m.post(
+                    "http://test:8018/services/user/mpd.service/start",
+                    status=204,
+                )
+
+                await api.control_service("start", "user", "mpd.service")
+
+                assert len(m.requests) == 1
+
+    @pytest.mark.asyncio
+    async def test_control_service_stop(self):
+        """Test control_service stop."""
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with aioresponses() as m:
+                m.post(
+                    "http://test:8018/services/user/kodi.service/stop",
+                    status=204,
+                )
+
+                await api.control_service("stop", "user", "kodi.service")
+
+                assert len(m.requests) == 1
+
+    @pytest.mark.asyncio
     async def test_control_service_invalid_action(self):
         """Test control_service with invalid action raises ValueError."""
         async with ClientSession() as session:

--- a/custom_components/odio_remote/tests/test_switch.py
+++ b/custom_components/odio_remote/tests/test_switch.py
@@ -1,0 +1,294 @@
+"""Tests for Odio Remote switch platform."""
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.odio_remote.switch import OdioServiceSwitch, async_setup_entry
+
+from .conftest import MOCK_ALL_SERVICES, MOCK_SERVER_INFO, MOCK_SERVICES
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_coordinator(services=None, last_update_success=True):
+    """Return a minimal mock OdioServiceCoordinator."""
+    coord = MagicMock()
+    coord.data = {"services": services} if services is not None else None
+    coord.last_update_success = last_update_success
+    coord.async_request_refresh = AsyncMock()
+    return coord
+
+
+def _make_switch(service_info, coordinator=None):
+    """Instantiate OdioServiceSwitch with a mock coordinator."""
+    if coordinator is None:
+        coordinator = _make_coordinator([service_info])
+    return OdioServiceSwitch(
+        coordinator,
+        api=MagicMock(),
+        entry_id="test_entry_id",
+        service_info=service_info,
+        server_hostname="htpc",
+    )
+
+
+def _make_entry(service_coordinator):
+    """Return a minimal mock config entry."""
+    entry = MagicMock()
+    entry.entry_id = "test_entry_id"
+    entry.runtime_data.server_info = MOCK_SERVER_INFO
+    entry.runtime_data.service_coordinator = service_coordinator
+    entry.runtime_data.api = MagicMock()
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# Entity construction
+# ---------------------------------------------------------------------------
+
+class TestOdioServiceSwitchConstruction:
+    """Tests for OdioServiceSwitch identity and naming."""
+
+    def test_unique_id(self):
+        """unique_id encodes scope and service name."""
+        svc = MOCK_SERVICES[0]  # mpd.service / user
+        entity = _make_switch(svc)
+        assert entity.unique_id == "test_entry_id_switch_user_mpd.service"
+
+    def test_name_strips_service_suffix(self):
+        """Name removes the '.service' suffix."""
+        entity = _make_switch(MOCK_SERVICES[0])
+        assert entity.name == "mpd"
+
+    def test_name_without_service_suffix_unchanged(self):
+        """A unit name without '.service' is kept as-is."""
+        svc = {"name": "kodi", "scope": "user", "exists": True, "running": False}
+        entity = _make_switch(svc)
+        assert entity.name == "kodi"
+
+    def test_has_entity_name(self):
+        entity = _make_switch(MOCK_SERVICES[0])
+        assert entity._attr_has_entity_name is True
+
+    def test_device_info_uses_hostname(self):
+        entity = _make_switch(MOCK_SERVICES[0])
+        assert "htpc" in str(entity.device_info)
+
+
+# ---------------------------------------------------------------------------
+# is_on
+# ---------------------------------------------------------------------------
+
+class TestOdioServiceSwitchIsOn:
+    """Tests for the is_on property."""
+
+    def test_is_on_when_running(self):
+        """is_on is True when the service is running."""
+        svc = MOCK_SERVICES[0]  # running=True
+        entity = _make_switch(svc)
+        assert entity.is_on is True
+
+    def test_is_off_when_stopped(self):
+        """is_on is False when the service is not running."""
+        svc = MOCK_SERVICES[1]  # running=False
+        entity = _make_switch(svc)
+        assert entity.is_on is False
+
+    def test_is_off_when_service_not_in_data(self):
+        """is_on is False when the service name isn't present in coordinator data."""
+        svc = {"name": "unknown.service", "scope": "user", "exists": True, "running": True}
+        # coordinator holds mpd data, not unknown.service
+        coord = _make_coordinator([MOCK_SERVICES[0]])
+        entity = _make_switch(svc, coordinator=coord)
+        assert entity.is_on is False
+
+    def test_is_off_when_coordinator_data_is_none(self):
+        """is_on is False when coordinator.data is None."""
+        coord = _make_coordinator(services=None)
+        entity = _make_switch(MOCK_SERVICES[0], coordinator=coord)
+        assert entity.is_on is False
+
+    def test_is_on_matches_scope(self):
+        """is_on checks both name and scope to avoid false positives."""
+        user_svc = {"name": "mpd.service", "scope": "user", "exists": True, "running": True}
+        system_svc = {"name": "mpd.service", "scope": "system", "exists": True, "running": False}
+        coord = _make_coordinator([system_svc])  # only system-scope in data
+        entity = _make_switch(user_svc, coordinator=coord)
+        assert entity.is_on is False
+
+
+# ---------------------------------------------------------------------------
+# available
+# ---------------------------------------------------------------------------
+
+class TestOdioServiceSwitchAvailable:
+    """Tests for the available property."""
+
+    def test_available_when_coordinator_ok(self):
+        coord = _make_coordinator(MOCK_SERVICES, last_update_success=True)
+        entity = _make_switch(MOCK_SERVICES[0], coordinator=coord)
+        assert entity.available is True
+
+    def test_unavailable_when_last_update_failed(self):
+        coord = _make_coordinator(MOCK_SERVICES, last_update_success=False)
+        entity = _make_switch(MOCK_SERVICES[0], coordinator=coord)
+        assert entity.available is False
+
+    def test_unavailable_when_data_is_none(self):
+        coord = _make_coordinator(services=None, last_update_success=True)
+        entity = _make_switch(MOCK_SERVICES[0], coordinator=coord)
+        assert entity.available is False
+
+
+# ---------------------------------------------------------------------------
+# Turn on / turn off
+# ---------------------------------------------------------------------------
+
+class TestOdioServiceSwitchActions:
+    """Tests for async_turn_on and async_turn_off."""
+
+    @pytest.mark.asyncio
+    async def test_turn_on_calls_start(self):
+        """async_turn_on issues a 'start' action for the correct scope/unit."""
+        svc = MOCK_SERVICES[1]  # shairport-sync.service / user / stopped
+        coord = _make_coordinator(MOCK_SERVICES)
+        api = MagicMock()
+        api.control_service = AsyncMock()
+        entity = OdioServiceSwitch(coord, api, "test_entry_id", svc, "htpc")
+
+        with patch("custom_components.odio_remote.switch.asyncio.sleep", new=AsyncMock()):
+            await entity.async_turn_on()
+
+        api.control_service.assert_awaited_once_with(
+            "start", "user", "shairport-sync.service"
+        )
+
+    @pytest.mark.asyncio
+    async def test_turn_on_requests_refresh(self):
+        """async_turn_on triggers a coordinator refresh after the delay."""
+        svc = MOCK_SERVICES[1]
+        coord = _make_coordinator(MOCK_SERVICES)
+        api = MagicMock()
+        api.control_service = AsyncMock()
+        entity = OdioServiceSwitch(coord, api, "test_entry_id", svc, "htpc")
+
+        with patch("custom_components.odio_remote.switch.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            await entity.async_turn_on()
+
+        mock_sleep.assert_awaited_once_with(2)
+        coord.async_request_refresh.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_turn_off_calls_stop(self):
+        """async_turn_off issues a 'stop' action for the correct scope/unit."""
+        svc = MOCK_SERVICES[0]  # mpd.service / user / running
+        coord = _make_coordinator(MOCK_SERVICES)
+        api = MagicMock()
+        api.control_service = AsyncMock()
+        entity = OdioServiceSwitch(coord, api, "test_entry_id", svc, "htpc")
+
+        with patch("custom_components.odio_remote.switch.asyncio.sleep", new=AsyncMock()):
+            await entity.async_turn_off()
+
+        api.control_service.assert_awaited_once_with(
+            "stop", "user", "mpd.service"
+        )
+
+    @pytest.mark.asyncio
+    async def test_turn_off_requests_refresh(self):
+        """async_turn_off triggers a coordinator refresh after the delay."""
+        svc = MOCK_SERVICES[0]
+        coord = _make_coordinator(MOCK_SERVICES)
+        api = MagicMock()
+        api.control_service = AsyncMock()
+        entity = OdioServiceSwitch(coord, api, "test_entry_id", svc, "htpc")
+
+        with patch("custom_components.odio_remote.switch.asyncio.sleep", new=AsyncMock()) as mock_sleep:
+            await entity.async_turn_off()
+
+        mock_sleep.assert_awaited_once_with(2)
+        coord.async_request_refresh.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# async_setup_entry
+# ---------------------------------------------------------------------------
+
+class TestOdioSwitchSetupEntry:
+    """Tests for the async_setup_entry platform entry point."""
+
+    @pytest.mark.asyncio
+    async def test_creates_user_scope_entities(self):
+        """Only user-scope services become switch entities."""
+        # MOCK_ALL_SERVICES has 1 system + 5 user services, all existing
+        coord = _make_coordinator(MOCK_ALL_SERVICES)
+        entry = _make_entry(coord)
+        added = []
+
+        await async_setup_entry(MagicMock(), entry, lambda entities: added.extend(entities))
+
+        assert len(added) == 5  # all user-scope ones
+        for entity in added:
+            assert entity._service_info["scope"] == "user"
+
+    @pytest.mark.asyncio
+    async def test_filters_system_scope(self):
+        """System-scope services are excluded."""
+        coord = _make_coordinator(MOCK_ALL_SERVICES)
+        entry = _make_entry(coord)
+        added = []
+
+        await async_setup_entry(MagicMock(), entry, lambda entities: added.extend(entities))
+
+        names = [e._service_info["name"] for e in added]
+        assert "bluetooth.service" not in names
+
+    @pytest.mark.asyncio
+    async def test_filters_non_existing_services(self):
+        """Services with exists=False are excluded."""
+        services = [
+            {"name": "mpd.service", "scope": "user", "exists": True, "running": False},
+            {"name": "ghost.service", "scope": "user", "exists": False, "running": False},
+        ]
+        coord = _make_coordinator(services)
+        entry = _make_entry(coord)
+        added = []
+
+        await async_setup_entry(MagicMock(), entry, lambda entities: added.extend(entities))
+
+        assert len(added) == 1
+        assert added[0]._service_info["name"] == "mpd.service"
+
+    @pytest.mark.asyncio
+    async def test_no_entities_when_no_coordinator(self):
+        """No entities are created when service_coordinator is None."""
+        entry = _make_entry(service_coordinator=None)
+        add_entities = MagicMock()
+
+        await async_setup_entry(MagicMock(), entry, add_entities)
+
+        add_entities.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_entities_when_coordinator_data_is_none(self):
+        """No entities are created when coordinator.data is None."""
+        coord = _make_coordinator(services=None)
+        entry = _make_entry(coord)
+        add_entities = MagicMock()
+
+        await async_setup_entry(MagicMock(), entry, add_entities)
+
+        add_entities.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entity_names_strip_service_suffix(self):
+        """Entities created by setup have names without '.service'."""
+        coord = _make_coordinator(MOCK_SERVICES)
+        entry = _make_entry(coord)
+        added = []
+
+        await async_setup_entry(MagicMock(), entry, lambda entities: added.extend(entities))
+
+        names = {e.name for e in added}
+        assert names == {"mpd", "shairport-sync", "snapclient"}


### PR DESCRIPTION
Adds OdioServiceSwitch (CoordinatorEntity[OdioServiceCoordinator]) for every user-scope service where exists=True. Turn on/off maps to POST /services/user/{unit}/start|stop followed by a coordinator refresh.

Also adds ENDPOINT_SERVICE_START/STOP constants, extends control_service in the API client, and covers the new platform with test_switch.py (25 cases) plus two new test_api_client.py cases for start/stop.