### PR TITLE
Add SSE event stream support for real-time coordinator updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ This integration connects to a Linux machine running the [go-odio-api server](ht
 - Always-visible connectivity binary_sensor (diagnostic category)
 - MAC address resolved via ARP and added to DeviceInfo.connections (“Connected via” in UI)
 - Clean state logic: `playing` / `idle` / `unavailable`
+- Real-time updates via SSE (Server-Sent Events) — no polling needed
+  - Automatic reconnection with exponential backoff
+  - Configurable keepalive interval (server-side heartbeat detection)
 
 ### Mapping to existing media players
 You can map Odio entities (services or remote clients) to any existing HA media_player entity via the configuration or reconfiguration flow.
@@ -115,7 +118,6 @@ Grouped under one device: “Odio Remote (hostname)”.
 
 ## Roadmap
 
-- SSE support for real-time updates (push instead of polling)
 - MPRIS player entities
 - Embed Bluetooth speaker support (pairing, enable/disable)
 - Audio outputs handling

--- a/custom_components/odio_remote/__init__.py
+++ b/custom_components/odio_remote/__init__.py
@@ -93,6 +93,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: OdioConfigEntry) -> bool
         sse_backends.append("audio")
     if backends.get("systemd"):
         sse_backends.append("systemd")
+    if backends.get("power"):
+        sse_backends.append("power")
 
     event_stream = OdioEventStreamManager(
         hass=hass,

--- a/custom_components/odio_remote/__init__.py
+++ b/custom_components/odio_remote/__init__.py
@@ -162,6 +162,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: OdioConfigEntry) -> bool
     if backends.get("systemd"):
         service_coordinator = OdioServiceCoordinator(hass, entry, api)
         await service_coordinator.async_refresh()
+        if service_coordinator.data:
+            services = service_coordinator.data.get("services", [])
+            if services != entry.data.get("cached_services"):
+                hass.config_entries.async_update_entry(
+                    entry, data={**entry.data, "cached_services": services}
+                )
         _LOGGER.debug("Service coordinator created (systemd backend enabled)")
 
     # Wire SSE event listeners now that coordinators exist.

--- a/custom_components/odio_remote/api_client.py
+++ b/custom_components/odio_remote/api_client.py
@@ -165,6 +165,7 @@ class OdioApiClient:
         self,
         backends: list[str] | None = None,
         exclude: list[str] | None = None,
+        keepalive_interval: int | None = None,
         keepalive_timeout: float | None = None,
     ) -> AsyncGenerator[SseEvent]:
         """Open an SSE connection to /events and yield parsed events.
@@ -184,6 +185,8 @@ class OdioApiClient:
             params["backend"] = ",".join(backends)
         if exclude:
             params["exclude"] = ",".join(exclude)
+        if keepalive_interval is not None:
+            params["keepalive"] = str(keepalive_interval)
 
         url = f"{self._api_url}{ENDPOINT_EVENTS}"
         _LOGGER.debug("Opening SSE connection to %s (params=%s)", url, params)

--- a/custom_components/odio_remote/api_client.py
+++ b/custom_components/odio_remote/api_client.py
@@ -1,13 +1,24 @@
 # custom_components/odio_remote/api_client.py
 
 import asyncio
+import json
 import logging
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
 from typing import Any
 from urllib.parse import quote
 
 import aiohttp
 
 _LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class SseEvent:
+    """A parsed Server-Sent Event."""
+
+    type: str
+    data: Any  # JSON-decoded payload
 
 
 class OdioApiClient:
@@ -148,6 +159,75 @@ class OdioApiClient:
         """Trigger reboot."""
         from .const import ENDPOINT_POWER_REBOOT
         await self.post(ENDPOINT_POWER_REBOOT)
+
+    # SSE event stream
+    async def listen_events(
+        self,
+        backends: list[str] | None = None,
+        exclude: list[str] | None = None,
+        keepalive_timeout: float | None = None,
+    ) -> AsyncGenerator[SseEvent]:
+        """Open an SSE connection to /events and yield parsed events.
+
+        This is a low-level generator that handles SSE wire-format parsing.
+        It does NOT handle reconnection — the caller is responsible for that.
+
+        Yields SseEvent instances for every received event including
+        server.info control events (connected, love, bye).
+
+        Raises on connection errors or when the stream ends.
+        """
+        from .const import ENDPOINT_EVENTS
+
+        params: dict[str, str] = {}
+        if backends:
+            params["backend"] = ",".join(backends)
+        if exclude:
+            params["exclude"] = ",".join(exclude)
+
+        url = f"{self._api_url}{ENDPOINT_EVENTS}"
+        _LOGGER.debug("Opening SSE connection to %s (params=%s)", url, params)
+
+        async with self._session.get(
+            url,
+            params=params,
+            headers={"Accept": "text/event-stream"},
+            timeout=aiohttp.ClientTimeout(total=None, sock_read=None),
+        ) as response:
+            response.raise_for_status()
+
+            event_type = ""
+            data_buf = ""
+
+            while not response.content.at_eof():
+                raw_line = await asyncio.wait_for(
+                    response.content.readline(), timeout=keepalive_timeout
+                )
+                if not raw_line:
+                    break
+                line = raw_line.decode("utf-8").rstrip("\r\n")
+
+                if line.startswith("event:"):
+                    event_type = line[len("event:"):].strip()
+                elif line.startswith("data:"):
+                    data_buf += line[len("data:"):].strip()
+                elif line == "":
+                    # Blank line marks end of an event
+                    if event_type and data_buf:
+                        try:
+                            parsed_data = json.loads(data_buf)
+                        except json.JSONDecodeError:
+                            _LOGGER.warning(
+                                "Failed to parse SSE data for event %s: %s",
+                                event_type,
+                                data_buf,
+                            )
+                            event_type = ""
+                            data_buf = ""
+                            continue
+                        yield SseEvent(type=event_type, data=parsed_data)
+                    event_type = ""
+                    data_buf = ""
 
     # Service control
     async def control_service(

--- a/custom_components/odio_remote/binary_sensor.py
+++ b/custom_components/odio_remote/binary_sensor.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Callable
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -11,10 +12,9 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import OdioConfigEntry
-from .coordinator import OdioConnectivityCoordinator
+from .event_stream import OdioEventStreamManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,37 +28,47 @@ async def async_setup_entry(
     runtime_data = entry.runtime_data
     async_add_entities([
         ConnectionStatusSensor(
-            runtime_data.connectivity_coordinator,
+            runtime_data.event_stream,
             entry.entry_id,
             runtime_data.device_info,
         )
     ])
 
 
-class ConnectionStatusSensor(CoordinatorEntity[OdioConnectivityCoordinator], BinarySensorEntity):
-    """Binary sensor reporting API connectivity for the Odio device."""
+class ConnectionStatusSensor(BinarySensorEntity):
+    """Binary sensor reporting SSE connectivity for the Odio device."""
 
     _attr_translation_key = "connection_status"
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_available = True
 
     def __init__(
         self,
-        coordinator: OdioConnectivityCoordinator,
+        event_stream: OdioEventStreamManager,
         entry_id: str,
         device_info: DeviceInfo,
     ) -> None:
-        super().__init__(coordinator)
+        self._event_stream = event_stream
         self._attr_unique_id = f"{entry_id}_connectivity"
         self._attr_device_info = device_info
+        self._unsub: Callable[[], None] | None = None
+
+    async def async_added_to_hass(self) -> None:
+        self._unsub = self._event_stream.async_add_listener(
+            self._handle_connectivity_change
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        if self._unsub is not None:
+            self._unsub()
+            self._unsub = None
+
+    def _handle_connectivity_change(self) -> None:
+        self.async_write_ha_state()
 
     @property
     def is_on(self) -> bool:
-        """Return True when the API is reachable."""
-        return self.coordinator.last_update_success
-
-    @property
-    def available(self) -> bool:
-        """The sensor itself is always available — it reports connectivity, not state."""
-        return True
+        """Return True when the SSE stream is connected."""
+        return self._event_stream.sse_connected

--- a/custom_components/odio_remote/button.py
+++ b/custom_components/odio_remote/button.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Callable
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.core import HomeAssistant
@@ -52,17 +51,11 @@ class _OdioPowerButtonBase(ButtonEntity):
         self._event_stream = event_stream
         self._api = api
         self._attr_device_info = device_info
-        self._unsub: Callable[[], None] | None = None
 
     async def async_added_to_hass(self) -> None:
-        self._unsub = self._event_stream.async_add_listener(
-            self.async_write_ha_state
+        self.async_on_remove(
+            self._event_stream.async_add_listener(self.async_write_ha_state)
         )
-
-    async def async_will_remove_from_hass(self) -> None:
-        if self._unsub is not None:
-            self._unsub()
-            self._unsub = None
 
     @property
     def available(self) -> bool:

--- a/custom_components/odio_remote/const.py
+++ b/custom_components/odio_remote/const.py
@@ -5,13 +5,11 @@ DOMAIN: Final = "odio_remote"
 
 # Config Flow
 CONF_API_URL: Final = "api_url"
-CONF_SCAN_INTERVAL: Final = "scan_interval"
-CONF_SERVICE_SCAN_INTERVAL: Final = "service_scan_interval"
+CONF_KEEPALIVE_INTERVAL: Final = "keepalive_interval"
 CONF_SERVICE_MAPPINGS: Final = "service_mappings"
 
 # Defaults
-DEFAULT_SCAN_INTERVAL: Final = 5  # secondes pour audio
-DEFAULT_SERVICE_SCAN_INTERVAL: Final = 60  # secondes pour services
+DEFAULT_KEEPALIVE_INTERVAL: Final = 30  # seconds, server-side SSE keepalive (range 10-120)
 DEFAULT_NAME: Final = "Odio Remote"
 
 # API Endpoints
@@ -41,7 +39,7 @@ SSE_EVENT_SERVER_INFO: Final = "server.info"
 # SSE reconnection
 SSE_RECONNECT_MIN_INTERVAL: Final = 1  # seconds
 SSE_RECONNECT_MAX_INTERVAL: Final = 300  # 5 minutes max backoff
-SSE_KEEPALIVE_TIMEOUT: Final = 45  # 30s server keepalive + 15s buffer
+SSE_KEEPALIVE_BUFFER: Final = 15  # seconds added to keepalive_interval for client timeout
 
 # Attributes
 ATTR_CLIENT_ID: Final = "client_id"

--- a/custom_components/odio_remote/const.py
+++ b/custom_components/odio_remote/const.py
@@ -32,6 +32,17 @@ ENDPOINT_POWER_OFF: Final = "/power/power_off"
 ENDPOINT_POWER_REBOOT: Final = "/power/reboot"
 ENDPOINT_SERVICE_START: Final = "/services/{scope}/{unit}/start"
 ENDPOINT_SERVICE_STOP: Final = "/services/{scope}/{unit}/stop"
+ENDPOINT_EVENTS: Final = "/events"
+
+# SSE event types
+SSE_EVENT_AUDIO_UPDATED: Final = "audio.updated"
+SSE_EVENT_SERVICE_UPDATED: Final = "service.updated"
+SSE_EVENT_SERVER_INFO: Final = "server.info"
+
+# SSE reconnection
+SSE_RECONNECT_MIN_INTERVAL: Final = 1  # seconds
+SSE_RECONNECT_MAX_INTERVAL: Final = 300  # 5 minutes max backoff
+SSE_KEEPALIVE_TIMEOUT: Final = 45  # 30s server keepalive + 15s buffer
 
 # Attributes
 ATTR_CLIENT_ID: Final = "client_id"

--- a/custom_components/odio_remote/const.py
+++ b/custom_components/odio_remote/const.py
@@ -34,6 +34,7 @@ ENDPOINT_EVENTS: Final = "/events"
 # SSE event types
 SSE_EVENT_AUDIO_UPDATED: Final = "audio.updated"
 SSE_EVENT_SERVICE_UPDATED: Final = "service.updated"
+SSE_EVENT_POWER_ACTION: Final = "power.action"
 SSE_EVENT_SERVER_INFO: Final = "server.info"
 
 # SSE reconnection

--- a/custom_components/odio_remote/const.py
+++ b/custom_components/odio_remote/const.py
@@ -12,7 +12,6 @@ CONF_SERVICE_MAPPINGS: Final = "service_mappings"
 # Defaults
 DEFAULT_SCAN_INTERVAL: Final = 5  # secondes pour audio
 DEFAULT_SERVICE_SCAN_INTERVAL: Final = 60  # secondes pour services
-DEFAULT_CONNECTIVITY_SCAN_INTERVAL: Final = 30  # secondes pour le heartbeat de connectivité
 DEFAULT_NAME: Final = "Odio Remote"
 
 # API Endpoints

--- a/custom_components/odio_remote/event_stream.py
+++ b/custom_components/odio_remote/event_stream.py
@@ -169,7 +169,6 @@ class OdioEventStreamManager:
 
         async for event in self._api.listen_events(
             backends=self._backends,
-            exclude=["player.position"],
             keepalive_interval=self._keepalive_interval,
             keepalive_timeout=self._keepalive_interval + SSE_KEEPALIVE_BUFFER,
         ):

--- a/custom_components/odio_remote/event_stream.py
+++ b/custom_components/odio_remote/event_stream.py
@@ -121,12 +121,18 @@ class OdioEventStreamManager:
     def _set_sse_connected(self, value: bool) -> None:
         if self._sse_connected != value:
             self._sse_connected = value
-            for callback in self._listeners:
-                callback()
+            for cb in list(self._listeners):
+                try:
+                    cb()
+                except Exception:
+                    _LOGGER.exception("Error in connectivity listener")
 
     def _dispatch_event(self, event: SseEvent) -> None:
-        for callback in self._event_listeners.get(event.type, []):
-            callback(event)
+        for cb in list(self._event_listeners.get(event.type, [])):
+            try:
+                cb(event)
+            except Exception:
+                _LOGGER.exception("Error in event listener for %s", event.type)
 
     async def _run_loop(self) -> None:
         """Run the SSE event loop with reconnection logic."""

--- a/custom_components/odio_remote/event_stream.py
+++ b/custom_components/odio_remote/event_stream.py
@@ -59,18 +59,6 @@ class OdioEventStreamManager:
         """Return True if the SSE connection is currently established."""
         return self._sse_connected
 
-    @property
-    def is_api_reachable(self) -> bool:
-        """Return True if the API is believed to be reachable.
-
-        Returns True during startup (before the stream is started) so that
-        coordinators can perform their initial fetch unconditionally.
-        Once the stream has started, reflects the live connection state.
-        """
-        if self._task is None:
-            return True
-        return self.connected
-
     def async_add_listener(self, callback: Callable[[], None]) -> Callable[[], None]:
         """Register a connectivity state listener. Returns an unsubscribe function."""
         self._listeners.append(callback)

--- a/custom_components/odio_remote/event_stream.py
+++ b/custom_components/odio_remote/event_stream.py
@@ -54,6 +54,18 @@ class OdioEventStreamManager:
         """Return True if the SSE stream task is running."""
         return self._task is not None and not self._task.done()
 
+    @property
+    def is_api_reachable(self) -> bool:
+        """Return True if the API is believed to be reachable.
+
+        Returns True during startup (before the stream is started) so that
+        coordinators can perform their initial fetch unconditionally.
+        Once the stream has started, reflects the live connection state.
+        """
+        if self._task is None:
+            return True
+        return self.connected
+
     def start(self) -> None:
         """Start the event stream in a background task."""
         if self._task is not None and not self._task.done():

--- a/custom_components/odio_remote/event_stream.py
+++ b/custom_components/odio_remote/event_stream.py
@@ -1,0 +1,214 @@
+"""SSE event stream manager for the Odio Remote integration."""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING
+
+import aiohttp
+
+from .api_client import OdioApiClient, SseEvent
+from .const import (
+    SSE_EVENT_AUDIO_UPDATED,
+    SSE_EVENT_SERVER_INFO,
+    SSE_EVENT_SERVICE_UPDATED,
+    SSE_KEEPALIVE_TIMEOUT,
+    SSE_RECONNECT_MAX_INTERVAL,
+    SSE_RECONNECT_MIN_INTERVAL,
+)
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
+    from .coordinator import OdioAudioCoordinator, OdioServiceCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class OdioEventStreamManager:
+    """Manage an SSE connection and route events to coordinators.
+
+    Handles reconnection with exponential backoff and keepalive timeout
+    detection. Events are dispatched to the appropriate coordinator:
+      - audio.updated  → audio_coordinator.async_set_updated_data()
+      - service.updated → merged into service_coordinator data
+    """
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        api: OdioApiClient,
+        audio_coordinator: OdioAudioCoordinator | None,
+        service_coordinator: OdioServiceCoordinator | None,
+    ) -> None:
+        """Initialize the event stream manager."""
+        self._hass = hass
+        self._api = api
+        self._audio_coordinator = audio_coordinator
+        self._service_coordinator = service_coordinator
+        self._task: asyncio.Task | None = None
+        self._stop_event = asyncio.Event()
+
+    @property
+    def connected(self) -> bool:
+        """Return True if the SSE stream task is running."""
+        return self._task is not None and not self._task.done()
+
+    def start(self) -> None:
+        """Start the event stream in a background task."""
+        if self._task is not None and not self._task.done():
+            _LOGGER.debug("Event stream already running")
+            return
+        self._stop_event.clear()
+        self._task = self._hass.async_create_background_task(
+            self._run_loop(),
+            name="odio_remote_event_stream",
+        )
+        _LOGGER.info("Event stream started")
+
+    async def stop(self) -> None:
+        """Stop the event stream."""
+        self._stop_event.set()
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+        self._task = None
+        _LOGGER.info("Event stream stopped")
+
+    async def _run_loop(self) -> None:
+        """Run the SSE event loop with reconnection logic."""
+        backoff = SSE_RECONNECT_MIN_INTERVAL
+
+        while not self._stop_event.is_set():
+            try:
+                await self._consume_stream()
+                # Stream ended cleanly (e.g. server sent "bye") — reconnect quickly
+                backoff = SSE_RECONNECT_MIN_INTERVAL
+                _LOGGER.info("SSE stream ended cleanly, reconnecting in %ds", backoff)
+            except asyncio.CancelledError:
+                _LOGGER.debug("Event stream cancelled")
+                return
+            except asyncio.TimeoutError:
+                _LOGGER.warning(
+                    "SSE keepalive timeout, reconnecting in %ds", backoff
+                )
+            except aiohttp.ClientError as err:
+                _LOGGER.warning(
+                    "SSE connection error: %s, reconnecting in %ds", err, backoff
+                )
+            except Exception:
+                _LOGGER.exception(
+                    "Unexpected SSE error, reconnecting in %ds", backoff
+                )
+
+            # Wait before reconnecting (interruptible by stop)
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=backoff
+                )
+                # stop_event was set — exit
+                return
+            except asyncio.TimeoutError:
+                # Backoff elapsed — reconnect
+                pass
+
+            backoff = min(backoff * 2, SSE_RECONNECT_MAX_INTERVAL)
+
+    async def _consume_stream(self) -> None:
+        """Open one SSE connection and process events until it ends."""
+        backends = self._get_backends()
+        if not backends:
+            _LOGGER.debug("No backends to subscribe to, skipping SSE")
+            # Wait until stopped to avoid busy-looping
+            await self._stop_event.wait()
+            return
+
+        async for event in self._api.listen_events(
+            backends=backends,
+            exclude=["player.position"],
+            keepalive_timeout=SSE_KEEPALIVE_TIMEOUT,
+        ):
+            if event.type == SSE_EVENT_SERVER_INFO:
+                self._handle_server_info(event)
+                continue
+
+            if event.type == SSE_EVENT_AUDIO_UPDATED:
+                self._handle_audio_updated(event)
+            elif event.type == SSE_EVENT_SERVICE_UPDATED:
+                self._handle_service_updated(event)
+            else:
+                _LOGGER.debug("Ignoring unhandled SSE event: %s", event.type)
+
+        _LOGGER.debug("SSE stream ended (at_eof)")
+
+    def _get_backends(self) -> list[str]:
+        """Build the list of backends to subscribe to."""
+        backends: list[str] = []
+        if self._audio_coordinator is not None:
+            backends.append("audio")
+        if self._service_coordinator is not None:
+            backends.append("systemd")
+        return backends
+
+    def _handle_server_info(self, event: SseEvent) -> None:
+        """Handle server.info control events (connected, love, bye)."""
+        if event.data == "connected":
+            _LOGGER.info("SSE stream connected")
+        elif event.data == "love":
+            _LOGGER.debug("SSE keepalive received")
+        elif event.data == "bye":
+            _LOGGER.info("SSE server sent bye")
+        else:
+            _LOGGER.debug("SSE server.info: %s", event.data)
+
+    def _handle_audio_updated(self, event: SseEvent) -> None:
+        """Handle audio.updated: full client list replacement."""
+        if self._audio_coordinator is None:
+            return
+        if not isinstance(event.data, list):
+            _LOGGER.warning(
+                "audio.updated: expected list, got %s", type(event.data).__name__
+            )
+            return
+        _LOGGER.debug("SSE audio.updated: %d clients", len(event.data))
+        self._audio_coordinator.async_set_updated_data({"audio": event.data})
+
+    def _handle_service_updated(self, event: SseEvent) -> None:
+        """Handle service.updated: merge single service into existing list."""
+        if self._service_coordinator is None:
+            return
+        if not isinstance(event.data, dict):
+            _LOGGER.warning(
+                "service.updated: expected dict, got %s",
+                type(event.data).__name__,
+            )
+            return
+
+        svc_name = event.data.get("name")
+        svc_scope = event.data.get("scope")
+        if not svc_name or not svc_scope:
+            _LOGGER.warning(
+                "service.updated: missing name or scope in %s", event.data
+            )
+            return
+
+        # Merge into existing services list
+        current = self._service_coordinator.data or {"services": []}
+        services = list(current.get("services", []))
+
+        replaced = False
+        for i, svc in enumerate(services):
+            if svc.get("name") == svc_name and svc.get("scope") == svc_scope:
+                services[i] = event.data
+                replaced = True
+                break
+        if not replaced:
+            services.append(event.data)
+
+        _LOGGER.debug(
+            "SSE service.updated: %s/%s (replaced=%s)", svc_scope, svc_name, replaced
+        )
+        self._service_coordinator.async_set_updated_data({"services": services})

--- a/custom_components/odio_remote/event_stream.py
+++ b/custom_components/odio_remote/event_stream.py
@@ -164,6 +164,7 @@ class OdioEventStreamManager:
         """Open one SSE connection and process events until it ends."""
         if not self._backends:
             _LOGGER.debug("No backends to subscribe to, skipping SSE")
+            self._set_sse_connected(True)
             await self._stop_event.wait()
             return
 

--- a/custom_components/odio_remote/media_player.py
+++ b/custom_components/odio_remote/media_player.py
@@ -366,20 +366,14 @@ class OdioServiceMediaPlayer(MappedEntityMixin, CoordinatorEntity, MediaPlayerEn
         """Return the key used in service_mappings."""
         return f"{self._service_info['scope']}/{self._service_info['name']}"
 
-    @callback
-    def _handle_coordinator_update(self) -> None:
-        """Handle updated data from the coordinator."""
-        super()._handle_coordinator_update()
+    async def async_added_to_hass(self) -> None:
+        """Register listener on the service coordinator."""
+        await super().async_added_to_hass()
         self.async_on_remove(
             self._service_coordinator.async_add_listener(
-                self._handle_service_coordinator_update
+                self.async_write_ha_state
             )
         )
-
-    @callback
-    def _handle_service_coordinator_update(self) -> None:
-        """Handle updated data from the service coordinator."""
-        self.async_write_ha_state()
 
     @property
     def state(self) -> MediaPlayerState:

--- a/custom_components/odio_remote/media_player.py
+++ b/custom_components/odio_remote/media_player.py
@@ -271,6 +271,9 @@ class OdioReceiverMediaPlayer(MediaPlayerEntity):
     @property
     def state(self) -> MediaPlayerState | None:
         """Return the state of the device."""
+        if not self._event_stream.sse_connected:
+            return MediaPlayerState.OFF
+
         if self._audio_coordinator is None:
             return MediaPlayerState.OFF
 
@@ -351,6 +354,7 @@ class OdioServiceMediaPlayer(MappedEntityMixin, CoordinatorEntity, MediaPlayerEn
         coordinator = ctx.audio_coordinator or ctx.service_coordinator
         super().__init__(coordinator)
         self._service_coordinator: OdioServiceCoordinator = ctx.service_coordinator
+        self._event_stream = ctx.event_stream
         self._api_client = ctx.api
         self._service_info = service_info
 
@@ -367,13 +371,19 @@ class OdioServiceMediaPlayer(MappedEntityMixin, CoordinatorEntity, MediaPlayerEn
         return f"{self._service_info['scope']}/{self._service_info['name']}"
 
     async def async_added_to_hass(self) -> None:
-        """Register listener on the service coordinator."""
+        """Register listener on the service coordinator and SSE stream."""
         await super().async_added_to_hass()
         self.async_on_remove(
-            self._service_coordinator.async_add_listener(
-                self.async_write_ha_state
-            )
+            self._service_coordinator.async_add_listener(self.async_write_ha_state)
         )
+        self.async_on_remove(
+            self._event_stream.async_add_listener(self.async_write_ha_state)
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return False when the SSE stream is disconnected."""
+        return self._event_stream.sse_connected and super().available
 
     @property
     def state(self) -> MediaPlayerState:
@@ -557,6 +567,7 @@ class OdioPulseClientMediaPlayer(MappedEntityMixin, CoordinatorEntity, MediaPlay
         assert ctx.audio_coordinator is not None
         super().__init__(ctx.audio_coordinator)
         self._api_client = ctx.api
+        self._event_stream = ctx.event_stream
         self._server_hostname_value = ctx.server_hostname
 
         self._client_name = initial_client.get("name", "")
@@ -656,10 +667,17 @@ class OdioPulseClientMediaPlayer(MappedEntityMixin, CoordinatorEntity, MediaPlay
             attrs["app_version"] = props["application.version"]
         return attrs
 
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to SSE connectivity changes in addition to coordinator updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._event_stream.async_add_listener(self.async_write_ha_state)
+        )
+
     @property
     def available(self) -> bool:
-        """Return if entity is available."""
-        return True
+        """Return False when the SSE stream is disconnected."""
+        return self._event_stream.sse_connected
 
     def _get_current_client(self) -> dict[str, Any] | None:
         """Get the current client data from coordinator by NAME."""

--- a/custom_components/odio_remote/strings.json
+++ b/custom_components/odio_remote/strings.json
@@ -11,16 +11,14 @@
           "api_url": "L'URL de base de votre API go-odio-api (ex: http://192.168.1.100:8018)"
         }
       },
-      "options": {
-        "title": "Paramètres de scan",
-        "description": "Configurez les intervalles de mise à jour",
+      "sse": {
+        "title": "Configuration SSE",
+        "description": "Configurez l'intervalle de keepalive SSE",
         "data": {
-          "scan_interval": "Intervalle de scan audio (secondes)",
-          "service_scan_interval": "Intervalle de scan services (secondes)"
+          "keepalive_interval": "Intervalle de keepalive (secondes)"
         },
         "data_description": {
-          "scan_interval": "Fréquence de mise à jour des clients audio (recommandé: 5s)",
-          "service_scan_interval": "Fréquence de mise à jour des services (recommandé: 60s)"
+          "keepalive_interval": "Intervalle de heartbeat serveur, 10-120s (recommandé : 30s)"
         }
       },
       "zeroconf_confirm": {
@@ -57,20 +55,18 @@
         "title": "Options Odio Remote",
         "description": "Que souhaitez-vous configurer pour {name} ?",
         "menu_options": {
-          "intervals": "Modifier les intervalles de scan",
+          "sse": "Configurer les paramètres SSE",
           "mappings": "Gérer les associations d'entités"
         }
       },
-      "intervals": {
-        "title": "Intervalles de scan",
-        "description": "Configurez les intervalles de mise à jour",
+      "sse": {
+        "title": "Paramètres SSE",
+        "description": "Configurez l'intervalle de keepalive SSE",
         "data": {
-          "scan_interval": "Intervalle de scan audio (secondes)",
-          "service_scan_interval": "Intervalle de scan services (secondes)"
+          "keepalive_interval": "Intervalle de keepalive (secondes)"
         },
         "data_description": {
-          "scan_interval": "Fréquence de mise à jour des clients audio (recommandé: 5s)",
-          "service_scan_interval": "Fréquence de mise à jour des services (recommandé: 60s)"
+          "keepalive_interval": "Intervalle de heartbeat serveur, 10-120s (recommandé : 30s)"
         }
       },
       "mappings": {

--- a/custom_components/odio_remote/switch.py
+++ b/custom_components/odio_remote/switch.py
@@ -1,7 +1,6 @@
 """Switch platform for Odio Remote — start/stop user-scope systemd services."""
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -146,13 +145,9 @@ class OdioServiceSwitch(CoordinatorEntity[OdioServiceCoordinator], SwitchEntity)
         await self._api.control_service(
             "start", self._service_info["scope"], self._service_info["name"]
         )
-        await asyncio.sleep(2)
-        await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Stop the service."""
         await self._api.control_service(
             "stop", self._service_info["scope"], self._service_info["name"]
         )
-        await asyncio.sleep(2)
-        await self.coordinator.async_request_refresh()

--- a/custom_components/odio_remote/switch.py
+++ b/custom_components/odio_remote/switch.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import OdioConfigEntry
 from .api_client import OdioApiClient
 from .coordinator import OdioServiceCoordinator
+from .event_stream import OdioEventStreamManager
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,6 +32,7 @@ class _SwitchContext:
     service_coordinator: OdioServiceCoordinator
     api: OdioApiClient
     device_info: DeviceInfo
+    event_stream: OdioEventStreamManager
 
 
 # =============================================================================
@@ -55,16 +57,24 @@ async def async_setup_entry(
         service_coordinator=service_coordinator,
         api=rd.api,
         device_info=rd.device_info,
+        event_stream=rd.event_stream,
     )
 
-    entities = []
-    if service_coordinator.data:
-        entities = [
-            OdioServiceSwitch(ctx, svc)
-            for svc in service_coordinator.data.get("services", [])
-            if svc.get("exists") and svc.get("scope") == "user"
-        ]
-        _LOGGER.debug("Creating %d service switch entities", len(entities))
+    live_services = service_coordinator.data.get("services", []) if service_coordinator.data else []
+    cached_services = entry.data.get("cached_services", []) if not live_services else []
+    services_source = live_services or cached_services
+
+    entities = [
+        OdioServiceSwitch(ctx, svc)
+        for svc in services_source
+        if svc.get("exists") and svc.get("scope") == "user"
+    ]
+    if entities:
+        _LOGGER.debug(
+            "Creating %d service switch entities (%s)",
+            len(entities),
+            "live" if live_services else "cached",
+        )
 
     async_add_entities(entities)
 
@@ -116,6 +126,7 @@ class OdioServiceSwitch(CoordinatorEntity[OdioServiceCoordinator], SwitchEntity)
     def __init__(self, ctx: _SwitchContext, service_info: dict[str, Any]) -> None:
         super().__init__(ctx.service_coordinator)
         self._api = ctx.api
+        self._event_stream = ctx.event_stream
         self._service_info = service_info
 
         service_name: str = service_info["name"]
@@ -124,6 +135,13 @@ class OdioServiceSwitch(CoordinatorEntity[OdioServiceCoordinator], SwitchEntity)
         self._attr_unique_id = f"{ctx.entry_id}_switch_{scope}_{service_name}"
         self._attr_name = service_name.removesuffix(".service")
         self._attr_device_info = ctx.device_info
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to SSE connectivity changes in addition to coordinator updates."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self._event_stream.async_add_listener(self.async_write_ha_state)
+        )
 
     @property
     def is_on(self) -> bool:
@@ -137,8 +155,12 @@ class OdioServiceSwitch(CoordinatorEntity[OdioServiceCoordinator], SwitchEntity)
 
     @property
     def available(self) -> bool:
-        """Return False when the coordinator has no data."""
-        return self.coordinator.last_update_success and bool(self.coordinator.data)
+        """Return False when SSE is disconnected or coordinator has no data."""
+        return (
+            self._event_stream.sse_connected
+            and self.coordinator.last_update_success
+            and bool(self.coordinator.data)
+        )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Start the service."""

--- a/custom_components/odio_remote/tests/test_button.py
+++ b/custom_components/odio_remote/tests/test_button.py
@@ -17,10 +17,10 @@ from .conftest import MOCK_DEVICE_INFO
 ENTRY_ID = "test_entry_id"
 
 
-def _make_connectivity_coordinator(last_update_success=True):
-    coord = MagicMock()
-    coord.last_update_success = last_update_success
-    return coord
+def _make_event_stream(sse_connected=True):
+    stream = MagicMock()
+    stream.sse_connected = sse_connected
+    return stream
 
 
 @dataclass
@@ -28,7 +28,7 @@ class MockPowerRuntimeData:
     api: object
     device_info: object
     power_capabilities: dict
-    connectivity_coordinator: object
+    event_stream: object
 
 
 class MockConfigEntry:
@@ -38,7 +38,7 @@ class MockConfigEntry:
             api=api or MagicMock(),
             device_info=MOCK_DEVICE_INFO,
             power_capabilities=caps,
-            connectivity_coordinator=_make_connectivity_coordinator(),
+            event_stream=_make_event_stream(),
         )
 
 
@@ -80,9 +80,9 @@ class TestButtonSetup:
 class TestOdioPowerOffButton:
     """Tests for OdioPowerOffButton."""
 
-    def _make_button(self, api=None):
+    def _make_button(self, api=None, sse_connected=True):
         return OdioPowerOffButton(
-            _make_connectivity_coordinator(), api or MagicMock(), ENTRY_ID, MOCK_DEVICE_INFO
+            _make_event_stream(sse_connected), api or MagicMock(), ENTRY_ID, MOCK_DEVICE_INFO
         )
 
     @pytest.mark.asyncio
@@ -105,26 +105,18 @@ class TestOdioPowerOffButton:
         assert self._make_button().device_class is None
 
     def test_available_when_connectivity_up(self):
-        btn = OdioPowerOffButton(
-            _make_connectivity_coordinator(last_update_success=True),
-            MagicMock(), ENTRY_ID, MOCK_DEVICE_INFO,
-        )
-        assert btn.available is True
+        assert self._make_button(sse_connected=True).available is True
 
     def test_unavailable_when_connectivity_down(self):
-        btn = OdioPowerOffButton(
-            _make_connectivity_coordinator(last_update_success=False),
-            MagicMock(), ENTRY_ID, MOCK_DEVICE_INFO,
-        )
-        assert btn.available is False
+        assert self._make_button(sse_connected=False).available is False
 
 
 class TestOdioRebootButton:
     """Tests for OdioRebootButton."""
 
-    def _make_button(self, api=None):
+    def _make_button(self, api=None, sse_connected=True):
         return OdioRebootButton(
-            _make_connectivity_coordinator(), api or MagicMock(), ENTRY_ID, MOCK_DEVICE_INFO
+            _make_event_stream(sse_connected), api or MagicMock(), ENTRY_ID, MOCK_DEVICE_INFO
         )
 
     @pytest.mark.asyncio
@@ -147,15 +139,7 @@ class TestOdioRebootButton:
         assert self._make_button().translation_key == "reboot"
 
     def test_available_when_connectivity_up(self):
-        btn = OdioRebootButton(
-            _make_connectivity_coordinator(last_update_success=True),
-            MagicMock(), ENTRY_ID, MOCK_DEVICE_INFO,
-        )
-        assert btn.available is True
+        assert self._make_button(sse_connected=True).available is True
 
     def test_unavailable_when_connectivity_down(self):
-        btn = OdioRebootButton(
-            _make_connectivity_coordinator(last_update_success=False),
-            MagicMock(), ENTRY_ID, MOCK_DEVICE_INFO,
-        )
-        assert btn.available is False
+        assert self._make_button(sse_connected=False).available is False

--- a/custom_components/odio_remote/tests/test_coordinator.py
+++ b/custom_components/odio_remote/tests/test_coordinator.py
@@ -22,7 +22,10 @@ from .conftest import MOCK_CLIENTS, MOCK_SERVICES
 
 def _make_hass():
     hass = MagicMock()
-    hass.loop = asyncio.get_event_loop()
+    try:
+        hass.loop = asyncio.get_running_loop()
+    except RuntimeError:
+        hass.loop = MagicMock()
     return hass
 
 
@@ -124,8 +127,7 @@ class TestOdioServiceCoordinator:
 
 class TestAudioCoordinatorHandleSseEvent:
 
-    @pytest.mark.asyncio
-    async def test_valid_list_updates_data(self):
+    def test_valid_list_updates_data(self):
         """handle_sse_event sets coordinator data when event data is a list."""
         coord = _make_audio_coordinator(MagicMock())
         coord.async_set_updated_data = MagicMock()
@@ -135,8 +137,7 @@ class TestAudioCoordinatorHandleSseEvent:
 
         coord.async_set_updated_data.assert_called_once_with({"audio": [{"id": 1}]})
 
-    @pytest.mark.asyncio
-    async def test_non_list_data_ignored(self):
+    def test_non_list_data_ignored(self):
         """handle_sse_event does nothing when event data is not a list."""
         coord = _make_audio_coordinator(MagicMock())
         coord.async_set_updated_data = MagicMock()
@@ -145,8 +146,7 @@ class TestAudioCoordinatorHandleSseEvent:
 
         coord.async_set_updated_data.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_empty_list_updates_data(self):
+    def test_empty_list_updates_data(self):
         """handle_sse_event accepts an empty list."""
         coord = _make_audio_coordinator(MagicMock())
         coord.async_set_updated_data = MagicMock()
@@ -168,8 +168,7 @@ class TestServiceCoordinatorHandleSseEvent:
         coord.async_set_updated_data = MagicMock()
         return coord
 
-    @pytest.mark.asyncio
-    async def test_replaces_existing_service(self):
+    def test_replaces_existing_service(self):
         """handle_sse_event replaces a service matched by name+scope."""
         existing = {"name": "mpd.service", "scope": "user", "running": True}
         coord = self._make_coord_with_data([existing])
@@ -179,8 +178,7 @@ class TestServiceCoordinatorHandleSseEvent:
 
         coord.async_set_updated_data.assert_called_once_with({"services": [updated]})
 
-    @pytest.mark.asyncio
-    async def test_appends_unknown_service(self):
+    def test_appends_unknown_service(self):
         """handle_sse_event appends a service not in the current list."""
         existing = {"name": "mpd.service", "scope": "user", "running": True}
         coord = self._make_coord_with_data([existing])
@@ -192,8 +190,7 @@ class TestServiceCoordinatorHandleSseEvent:
             {"services": [existing, new_svc]}
         )
 
-    @pytest.mark.asyncio
-    async def test_non_dict_data_ignored(self):
+    def test_non_dict_data_ignored(self):
         """handle_sse_event does nothing when event data is not a dict."""
         coord = self._make_coord_with_data([])
 
@@ -201,8 +198,7 @@ class TestServiceCoordinatorHandleSseEvent:
 
         coord.async_set_updated_data.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_missing_name_ignored(self):
+    def test_missing_name_ignored(self):
         """handle_sse_event does nothing when event data has no 'name' key."""
         coord = self._make_coord_with_data([])
 
@@ -210,8 +206,7 @@ class TestServiceCoordinatorHandleSseEvent:
 
         coord.async_set_updated_data.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_missing_scope_ignored(self):
+    def test_missing_scope_ignored(self):
         """handle_sse_event does nothing when event data has no 'scope' key."""
         coord = self._make_coord_with_data([])
 
@@ -219,8 +214,7 @@ class TestServiceCoordinatorHandleSseEvent:
 
         coord.async_set_updated_data.assert_not_called()
 
-    @pytest.mark.asyncio
-    async def test_scope_must_match_for_replace(self):
+    def test_scope_must_match_for_replace(self):
         """A service with same name but different scope is appended, not replaced."""
         existing = {"name": "mpd.service", "scope": "user", "running": True}
         coord = self._make_coord_with_data([existing])
@@ -232,8 +226,7 @@ class TestServiceCoordinatorHandleSseEvent:
             {"services": [existing, system_svc]}
         )
 
-    @pytest.mark.asyncio
-    async def test_works_with_no_existing_data(self):
+    def test_works_with_no_existing_data(self):
         """handle_sse_event handles coordinator.data being None."""
         coord = _make_service_coordinator(MagicMock())
         coord.data = None

--- a/custom_components/odio_remote/tests/test_coordinator.py
+++ b/custom_components/odio_remote/tests/test_coordinator.py
@@ -7,6 +7,7 @@ import aiohttp
 
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from custom_components.odio_remote.api_client import SseEvent
 from custom_components.odio_remote.coordinator import (
     OdioAudioCoordinator,
     OdioServiceCoordinator,
@@ -211,3 +212,130 @@ class TestOdioServiceCoordinator:
 
         await coord._async_update_data()
         assert coord._failure_count == 0
+
+
+# ---------------------------------------------------------------------------
+# OdioAudioCoordinator.handle_sse_event
+# ---------------------------------------------------------------------------
+
+class TestAudioCoordinatorHandleSseEvent:
+
+    @pytest.mark.asyncio
+    async def test_valid_list_updates_data(self):
+        """handle_sse_event sets coordinator data when event data is a list."""
+        coord = _make_audio_coordinator(MagicMock())
+        coord.async_set_updated_data = MagicMock()
+
+        event = SseEvent(type="audio.updated", data=[{"id": 1}])
+        coord.handle_sse_event(event)
+
+        coord.async_set_updated_data.assert_called_once_with({"audio": [{"id": 1}]})
+
+    @pytest.mark.asyncio
+    async def test_non_list_data_ignored(self):
+        """handle_sse_event does nothing when event data is not a list."""
+        coord = _make_audio_coordinator(MagicMock())
+        coord.async_set_updated_data = MagicMock()
+
+        coord.handle_sse_event(SseEvent(type="audio.updated", data={"not": "a list"}))
+
+        coord.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_list_updates_data(self):
+        """handle_sse_event accepts an empty list."""
+        coord = _make_audio_coordinator(MagicMock())
+        coord.async_set_updated_data = MagicMock()
+
+        coord.handle_sse_event(SseEvent(type="audio.updated", data=[]))
+
+        coord.async_set_updated_data.assert_called_once_with({"audio": []})
+
+
+# ---------------------------------------------------------------------------
+# OdioServiceCoordinator.handle_sse_event
+# ---------------------------------------------------------------------------
+
+class TestServiceCoordinatorHandleSseEvent:
+
+    def _make_coord_with_data(self, services):
+        coord = _make_service_coordinator(MagicMock())
+        coord.data = {"services": services}
+        coord.async_set_updated_data = MagicMock()
+        return coord
+
+    @pytest.mark.asyncio
+    async def test_replaces_existing_service(self):
+        """handle_sse_event replaces a service matched by name+scope."""
+        existing = {"name": "mpd.service", "scope": "user", "running": True}
+        coord = self._make_coord_with_data([existing])
+
+        updated = {"name": "mpd.service", "scope": "user", "running": False}
+        coord.handle_sse_event(SseEvent(type="service.updated", data=updated))
+
+        coord.async_set_updated_data.assert_called_once_with({"services": [updated]})
+
+    @pytest.mark.asyncio
+    async def test_appends_unknown_service(self):
+        """handle_sse_event appends a service not in the current list."""
+        existing = {"name": "mpd.service", "scope": "user", "running": True}
+        coord = self._make_coord_with_data([existing])
+
+        new_svc = {"name": "snapclient.service", "scope": "user", "running": False}
+        coord.handle_sse_event(SseEvent(type="service.updated", data=new_svc))
+
+        coord.async_set_updated_data.assert_called_once_with(
+            {"services": [existing, new_svc]}
+        )
+
+    @pytest.mark.asyncio
+    async def test_non_dict_data_ignored(self):
+        """handle_sse_event does nothing when event data is not a dict."""
+        coord = self._make_coord_with_data([])
+
+        coord.handle_sse_event(SseEvent(type="service.updated", data=["not", "a", "dict"]))
+
+        coord.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_name_ignored(self):
+        """handle_sse_event does nothing when event data has no 'name' key."""
+        coord = self._make_coord_with_data([])
+
+        coord.handle_sse_event(SseEvent(type="service.updated", data={"scope": "user"}))
+
+        coord.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_scope_ignored(self):
+        """handle_sse_event does nothing when event data has no 'scope' key."""
+        coord = self._make_coord_with_data([])
+
+        coord.handle_sse_event(SseEvent(type="service.updated", data={"name": "mpd.service"}))
+
+        coord.async_set_updated_data.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_scope_must_match_for_replace(self):
+        """A service with same name but different scope is appended, not replaced."""
+        existing = {"name": "mpd.service", "scope": "user", "running": True}
+        coord = self._make_coord_with_data([existing])
+
+        system_svc = {"name": "mpd.service", "scope": "system", "running": False}
+        coord.handle_sse_event(SseEvent(type="service.updated", data=system_svc))
+
+        coord.async_set_updated_data.assert_called_once_with(
+            {"services": [existing, system_svc]}
+        )
+
+    @pytest.mark.asyncio
+    async def test_works_with_no_existing_data(self):
+        """handle_sse_event handles coordinator.data being None."""
+        coord = _make_service_coordinator(MagicMock())
+        coord.data = None
+        coord.async_set_updated_data = MagicMock()
+
+        svc = {"name": "mpd.service", "scope": "user", "running": True}
+        coord.handle_sse_event(SseEvent(type="service.updated", data=svc))
+
+        coord.async_set_updated_data.assert_called_once_with({"services": [svc]})

--- a/custom_components/odio_remote/tests/test_event_stream.py
+++ b/custom_components/odio_remote/tests/test_event_stream.py
@@ -2,15 +2,13 @@
 import asyncio
 import json
 
-import aiohttp
 import pytest
 from aiohttp import ClientSession
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from custom_components.odio_remote.api_client import OdioApiClient, SseEvent
 from custom_components.odio_remote.event_stream import OdioEventStreamManager
 
-from .conftest import MOCK_CLIENTS, MOCK_SERVICES
 
 
 def _make_sse_bytes(*events: tuple[str, object]) -> bytes:

--- a/custom_components/odio_remote/tests/test_event_stream.py
+++ b/custom_components/odio_remote/tests/test_event_stream.py
@@ -10,7 +10,6 @@ from custom_components.odio_remote.api_client import OdioApiClient, SseEvent
 from custom_components.odio_remote.event_stream import OdioEventStreamManager
 
 
-
 def _make_sse_bytes(*events: tuple[str, object]) -> bytes:
     """Build raw SSE byte stream from (event_type, data) tuples."""
     lines = []

--- a/custom_components/odio_remote/tests/test_event_stream.py
+++ b/custom_components/odio_remote/tests/test_event_stream.py
@@ -1,0 +1,547 @@
+"""Tests for OdioEventStreamManager."""
+import asyncio
+import json
+
+import aiohttp
+import pytest
+from aiohttp import ClientSession
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.odio_remote.api_client import OdioApiClient, SseEvent
+from custom_components.odio_remote.event_stream import OdioEventStreamManager
+
+from .conftest import MOCK_CLIENTS, MOCK_SERVICES
+
+
+def _make_sse_bytes(*events: tuple[str, object]) -> bytes:
+    """Build raw SSE byte stream from (event_type, data) tuples."""
+    lines = []
+    for event_type, data in events:
+        lines.append(f"event: {event_type}")
+        lines.append(f"data: {json.dumps(data)}")
+        lines.append("")  # blank line terminates the event
+    return "\n".join(lines).encode("utf-8") + b"\n"
+
+
+class TestListenEvents:
+    """Tests for OdioApiClient.listen_events() SSE parser."""
+
+    @pytest.mark.asyncio
+    async def test_parse_single_event(self):
+        """Test parsing a single SSE event."""
+        raw = _make_sse_bytes(("audio.updated", [{"id": 1, "name": "Spotify"}]))
+
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with patch.object(
+                session,
+                "get",
+                return_value=_mock_sse_response(raw),
+            ):
+                events = [e async for e in api.listen_events()]
+
+        assert len(events) == 1
+        assert events[0].type == "audio.updated"
+        assert events[0].data == [{"id": 1, "name": "Spotify"}]
+
+    @pytest.mark.asyncio
+    async def test_parse_multiple_events(self):
+        """Test parsing multiple consecutive SSE events."""
+        raw = _make_sse_bytes(
+            ("server.info", "connected"),
+            ("audio.updated", [{"id": 1}]),
+            ("service.updated", {"name": "mpd.service", "scope": "user"}),
+            ("server.info", "love"),
+        )
+
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with patch.object(
+                session,
+                "get",
+                return_value=_mock_sse_response(raw),
+            ):
+                events = [e async for e in api.listen_events()]
+
+        assert len(events) == 4
+        assert events[0].type == "server.info"
+        assert events[0].data == "connected"
+        assert events[1].type == "audio.updated"
+        assert events[2].type == "service.updated"
+        assert events[3].data == "love"
+
+    @pytest.mark.asyncio
+    async def test_parse_skips_invalid_json(self):
+        """Test that events with invalid JSON data are skipped."""
+        raw = (
+            b"event: audio.updated\n"
+            b"data: {not valid json\n"
+            b"\n"
+            b"event: server.info\n"
+            b"data: \"love\"\n"
+            b"\n"
+        )
+
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with patch.object(
+                session,
+                "get",
+                return_value=_mock_sse_response(raw),
+            ):
+                events = [e async for e in api.listen_events()]
+
+        assert len(events) == 1
+        assert events[0].type == "server.info"
+
+    @pytest.mark.asyncio
+    async def test_backend_and_exclude_params(self):
+        """Test that backend and exclude params are passed correctly."""
+        raw = _make_sse_bytes(("server.info", "connected"))
+
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with patch.object(
+                session,
+                "get",
+                return_value=_mock_sse_response(raw),
+            ) as mock_get:
+                _ = [
+                    e
+                    async for e in api.listen_events(
+                        backends=["audio", "systemd"],
+                        exclude=["player.position"],
+                    )
+                ]
+
+            call_kwargs = mock_get.call_args
+            assert call_kwargs.kwargs["params"] == {
+                "backend": "audio,systemd",
+                "exclude": "player.position",
+            }
+
+    @pytest.mark.asyncio
+    async def test_empty_stream(self):
+        """Test that an empty stream yields nothing."""
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with patch.object(
+                session,
+                "get",
+                return_value=_mock_sse_response(b""),
+            ):
+                events = [e async for e in api.listen_events()]
+
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_event_without_data_ignored(self):
+        """Test that an event type line followed by blank line (no data) is ignored."""
+        raw = b"event: audio.updated\n\n"
+
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with patch.object(
+                session,
+                "get",
+                return_value=_mock_sse_response(raw),
+            ):
+                events = [e async for e in api.listen_events()]
+
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_keepalive_timeout_raises(self):
+        """Test that a stalled stream raises TimeoutError after keepalive_timeout."""
+        import asyncio
+
+        class _StalledStreamReader:
+            def at_eof(self):
+                return False
+
+            async def readline(self):
+                await asyncio.sleep(3600)
+
+        class _StalledResponse:
+            content = _StalledStreamReader()
+            status = 200
+
+            def raise_for_status(self):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                pass
+
+        async with ClientSession() as session:
+            api = OdioApiClient("http://test:8018", session)
+
+            with patch.object(session, "get", return_value=_StalledResponse()):
+                with pytest.raises(asyncio.TimeoutError):
+                    async for _ in api.listen_events(keepalive_timeout=0.05):
+                        pass
+
+
+class TestEventStreamManagerHandlers:
+    """Tests for OdioEventStreamManager event routing."""
+
+    def test_handle_audio_updated(self):
+        """Test audio.updated replaces coordinator data."""
+        audio_coord = MagicMock()
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=audio_coord,
+            service_coordinator=None,
+        )
+
+        clients = [{"id": 1, "name": "Spotify", "volume": 0.75}]
+        event = SseEvent(type="audio.updated", data=clients)
+        manager._handle_audio_updated(event)
+
+        audio_coord.async_set_updated_data.assert_called_once_with(
+            {"audio": clients}
+        )
+
+    def test_handle_audio_updated_no_coordinator(self):
+        """Test audio.updated is a no-op when audio_coordinator is None."""
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=None,
+        )
+
+        event = SseEvent(type="audio.updated", data=[{"id": 1}])
+        # Should not raise
+        manager._handle_audio_updated(event)
+
+    def test_handle_audio_updated_invalid_data(self):
+        """Test audio.updated with non-list data is ignored."""
+        audio_coord = MagicMock()
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=audio_coord,
+            service_coordinator=None,
+        )
+
+        event = SseEvent(type="audio.updated", data={"not": "a list"})
+        manager._handle_audio_updated(event)
+
+        audio_coord.async_set_updated_data.assert_not_called()
+
+    def test_handle_service_updated_replace(self):
+        """Test service.updated replaces matching service in list."""
+        service_coord = MagicMock()
+        service_coord.data = {
+            "services": [
+                {"name": "mpd.service", "scope": "user", "running": True},
+                {"name": "snapclient.service", "scope": "user", "running": False},
+            ]
+        }
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=service_coord,
+        )
+
+        updated = {"name": "mpd.service", "scope": "user", "running": False}
+        event = SseEvent(type="service.updated", data=updated)
+        manager._handle_service_updated(event)
+
+        call_args = service_coord.async_set_updated_data.call_args[0][0]
+        services = call_args["services"]
+        assert len(services) == 2
+        assert services[0] == updated
+        assert services[1]["name"] == "snapclient.service"
+
+    def test_handle_service_updated_append(self):
+        """Test service.updated appends new service to list."""
+        service_coord = MagicMock()
+        service_coord.data = {
+            "services": [
+                {"name": "mpd.service", "scope": "user", "running": True},
+            ]
+        }
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=service_coord,
+        )
+
+        new_svc = {"name": "kodi.service", "scope": "user", "running": True}
+        event = SseEvent(type="service.updated", data=new_svc)
+        manager._handle_service_updated(event)
+
+        call_args = service_coord.async_set_updated_data.call_args[0][0]
+        services = call_args["services"]
+        assert len(services) == 2
+        assert services[1] == new_svc
+
+    def test_handle_service_updated_no_coordinator(self):
+        """Test service.updated is a no-op when service_coordinator is None."""
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=None,
+        )
+
+        event = SseEvent(type="service.updated", data={"name": "mpd.service", "scope": "user"})
+        # Should not raise
+        manager._handle_service_updated(event)
+
+    def test_handle_service_updated_invalid_data(self):
+        """Test service.updated with non-dict data is ignored."""
+        service_coord = MagicMock()
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=service_coord,
+        )
+
+        event = SseEvent(type="service.updated", data=["not", "a", "dict"])
+        manager._handle_service_updated(event)
+
+        service_coord.async_set_updated_data.assert_not_called()
+
+    def test_handle_service_updated_missing_key(self):
+        """Test service.updated with missing name or scope is ignored."""
+        service_coord = MagicMock()
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=service_coord,
+        )
+
+        event = SseEvent(type="service.updated", data={"name": "mpd.service"})
+        manager._handle_service_updated(event)
+
+        service_coord.async_set_updated_data.assert_not_called()
+
+    def test_handle_service_updated_empty_coordinator_data(self):
+        """Test service.updated when coordinator has no prior data."""
+        service_coord = MagicMock()
+        service_coord.data = None
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=service_coord,
+        )
+
+        svc = {"name": "mpd.service", "scope": "user", "running": True}
+        event = SseEvent(type="service.updated", data=svc)
+        manager._handle_service_updated(event)
+
+        call_args = service_coord.async_set_updated_data.call_args[0][0]
+        assert call_args == {"services": [svc]}
+
+    def test_get_backends_both(self):
+        """Test _get_backends returns both when both coordinators exist."""
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=MagicMock(),
+            service_coordinator=MagicMock(),
+        )
+        assert manager._get_backends() == ["audio", "systemd"]
+
+    def test_get_backends_audio_only(self):
+        """Test _get_backends returns audio only."""
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=MagicMock(),
+            service_coordinator=None,
+        )
+        assert manager._get_backends() == ["audio"]
+
+    def test_get_backends_none(self):
+        """Test _get_backends returns empty list when no coordinators."""
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=None,
+        )
+        assert manager._get_backends() == []
+
+    def test_handle_service_updated_scope_matters(self):
+        """Test that name+scope together identify the service."""
+        service_coord = MagicMock()
+        service_coord.data = {
+            "services": [
+                {"name": "bluetooth.service", "scope": "system", "running": True},
+                {"name": "bluetooth.service", "scope": "user", "running": False},
+            ]
+        }
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=service_coord,
+        )
+
+        # Update the user-scoped bluetooth only
+        updated = {"name": "bluetooth.service", "scope": "user", "running": True}
+        event = SseEvent(type="service.updated", data=updated)
+        manager._handle_service_updated(event)
+
+        call_args = service_coord.async_set_updated_data.call_args[0][0]
+        services = call_args["services"]
+        assert len(services) == 2
+        # system scope unchanged
+        assert services[0] == {"name": "bluetooth.service", "scope": "system", "running": True}
+        # user scope updated
+        assert services[1] == updated
+
+
+class TestEventStreamManagerLifecycle:
+    """Tests for start/stop lifecycle."""
+
+    def test_start_creates_task(self):
+        """Test that start creates a background task."""
+        hass = MagicMock()
+        task = MagicMock(spec=asyncio.Task)
+        task.done.return_value = False
+
+        def _fake_create_task(coro, **kwargs):
+            coro.close()
+            return task
+
+        hass.async_create_background_task = MagicMock(side_effect=_fake_create_task)
+        manager = OdioEventStreamManager(
+            hass=hass,
+            api=MagicMock(),
+            audio_coordinator=MagicMock(),
+            service_coordinator=None,
+        )
+
+        manager.start()
+
+        hass.async_create_background_task.assert_called_once()
+        assert manager.connected
+
+    def test_start_idempotent(self):
+        """Test that calling start twice doesn't create a second task."""
+        hass = MagicMock()
+        task = MagicMock(spec=asyncio.Task)
+        task.done.return_value = False
+
+        def _fake_create_task(coro, **kwargs):
+            coro.close()
+            return task
+
+        hass.async_create_background_task = MagicMock(side_effect=_fake_create_task)
+        manager = OdioEventStreamManager(
+            hass=hass,
+            api=MagicMock(),
+            audio_coordinator=MagicMock(),
+            service_coordinator=None,
+        )
+
+        manager.start()
+        manager.start()
+
+        assert hass.async_create_background_task.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_task(self):
+        """Test that stop sets the task to None."""
+        hass = MagicMock()
+
+        async def _forever():
+            await asyncio.sleep(3600)
+
+        real_task = asyncio.create_task(_forever())
+
+        def _fake_create_task(coro, **kwargs):
+            coro.close()
+            return real_task
+
+        hass.async_create_background_task = MagicMock(side_effect=_fake_create_task)
+
+        manager = OdioEventStreamManager(
+            hass=hass,
+            api=MagicMock(),
+            audio_coordinator=MagicMock(),
+            service_coordinator=None,
+        )
+        manager.start()
+        assert manager.connected
+
+        await manager.stop()
+
+        assert real_task.cancelled()
+        assert not manager.connected
+
+    def test_connected_false_when_no_task(self):
+        """Test connected is False before start."""
+        manager = OdioEventStreamManager(
+            hass=MagicMock(),
+            api=MagicMock(),
+            audio_coordinator=None,
+            service_coordinator=None,
+        )
+        assert not manager.connected
+
+
+# ── Helpers ──────────────────────────────────────────────────────
+
+
+class _MockStreamReader:
+    """Mock aiohttp StreamReader that yields lines from raw bytes."""
+
+    def __init__(self, raw: bytes) -> None:
+        self._lines = raw.split(b"\n")
+        self._index = 0
+
+    def at_eof(self) -> bool:
+        return self._index >= len(self._lines)
+
+    async def readline(self) -> bytes:
+        if self._index >= len(self._lines):
+            return b""
+        line = self._lines[self._index] + b"\n"
+        self._index += 1
+        return line
+
+
+class _MockResponse:
+    """Mock aiohttp response for SSE streams."""
+
+    def __init__(self, raw: bytes) -> None:
+        self.content = _MockStreamReader(raw)
+        self.status = 200
+
+    def raise_for_status(self) -> None:
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _mock_sse_response(raw: bytes):
+    """Create a mock context manager returning a mock SSE response."""
+    return _MockResponse(raw)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/custom_components/odio_remote/tests/test_switch.py
+++ b/custom_components/odio_remote/tests/test_switch.py
@@ -1,6 +1,6 @@
 """Tests for Odio Remote switch platform."""
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.odio_remote.switch import OdioServiceSwitch, _SwitchContext, async_setup_entry
 
@@ -133,24 +133,22 @@ class TestOdioServiceSwitchActions:
         ctx = _SwitchContext("test_entry_id", coord, api, MOCK_DEVICE_INFO)
         entity = OdioServiceSwitch(ctx, svc)
 
-        with patch("custom_components.odio_remote.switch.asyncio.sleep", new=AsyncMock()):
-            await entity.async_turn_on()
+        await entity.async_turn_on()
 
         api.control_service.assert_awaited_once_with("start", "user", "shairport-sync.service")
 
     @pytest.mark.asyncio
-    async def test_turn_on_requests_refresh(self):
+    async def test_turn_on_does_not_poll(self):
+        """State update is driven by SSE — no manual refresh after action."""
         svc = MOCK_SERVICES[1]
         coord = _make_coordinator(MOCK_SERVICES)
         api = MagicMock()
         api.control_service = AsyncMock()
         entity = OdioServiceSwitch(_SwitchContext("test_entry_id", coord, api, MOCK_DEVICE_INFO), svc)
 
-        with patch("custom_components.odio_remote.switch.asyncio.sleep", new=AsyncMock()) as mock_sleep:
-            await entity.async_turn_on()
+        await entity.async_turn_on()
 
-        mock_sleep.assert_awaited_once_with(2)
-        coord.async_request_refresh.assert_awaited_once()
+        coord.async_request_refresh.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_turn_off_calls_stop(self):
@@ -160,24 +158,22 @@ class TestOdioServiceSwitchActions:
         api.control_service = AsyncMock()
         entity = OdioServiceSwitch(_SwitchContext("test_entry_id", coord, api, MOCK_DEVICE_INFO), svc)
 
-        with patch("custom_components.odio_remote.switch.asyncio.sleep", new=AsyncMock()):
-            await entity.async_turn_off()
+        await entity.async_turn_off()
 
         api.control_service.assert_awaited_once_with("stop", "user", "mpd.service")
 
     @pytest.mark.asyncio
-    async def test_turn_off_requests_refresh(self):
+    async def test_turn_off_does_not_poll(self):
+        """State update is driven by SSE — no manual refresh after action."""
         svc = MOCK_SERVICES[0]
         coord = _make_coordinator(MOCK_SERVICES)
         api = MagicMock()
         api.control_service = AsyncMock()
         entity = OdioServiceSwitch(_SwitchContext("test_entry_id", coord, api, MOCK_DEVICE_INFO), svc)
 
-        with patch("custom_components.odio_remote.switch.asyncio.sleep", new=AsyncMock()) as mock_sleep:
-            await entity.async_turn_off()
+        await entity.async_turn_off()
 
-        mock_sleep.assert_awaited_once_with(2)
-        coord.async_request_refresh.assert_awaited_once()
+        coord.async_request_refresh.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/custom_components/odio_remote/tests/test_switch.py
+++ b/custom_components/odio_remote/tests/test_switch.py
@@ -20,14 +20,22 @@ def _make_coordinator(services=None, last_update_success=True):
     return coord
 
 
-def _make_ctx(coordinator=None, service_info=None):
+def _make_event_stream(sse_connected=True):
+    es = MagicMock()
+    es.sse_connected = sse_connected
+    es.async_add_listener = MagicMock(return_value=lambda: None)
+    return es
+
+
+def _make_ctx(coordinator=None, service_info=None, event_stream=None, api=None):
     if coordinator is None:
         coordinator = _make_coordinator([service_info] if service_info else [])
     return _SwitchContext(
         entry_id="test_entry_id",
         service_coordinator=coordinator,
-        api=MagicMock(),
+        api=api or MagicMock(),
         device_info=MOCK_DEVICE_INFO,
+        event_stream=event_stream or _make_event_stream(),
     )
 
 
@@ -43,6 +51,7 @@ def _make_entry(service_coordinator):
     entry.runtime_data.service_coordinator = service_coordinator
     entry.runtime_data.api = MagicMock()
     entry.runtime_data.device_info = MOCK_DEVICE_INFO
+    entry.runtime_data.event_stream = _make_event_stream()
     entry.async_on_unload = MagicMock()
     return entry
 
@@ -117,6 +126,12 @@ class TestOdioServiceSwitchAvailable:
         entity = _make_switch(MOCK_SERVICES[0], coordinator=_make_coordinator(services=None))
         assert entity.available is False
 
+    def test_unavailable_when_sse_disconnected(self):
+        es = _make_event_stream(sse_connected=False)
+        ctx = _make_ctx(coordinator=_make_coordinator(MOCK_SERVICES), event_stream=es)
+        entity = OdioServiceSwitch(ctx, MOCK_SERVICES[0])
+        assert entity.available is False
+
 
 # ---------------------------------------------------------------------------
 # Turn on / turn off
@@ -127,11 +142,9 @@ class TestOdioServiceSwitchActions:
     @pytest.mark.asyncio
     async def test_turn_on_calls_start(self):
         svc = MOCK_SERVICES[1]
-        coord = _make_coordinator(MOCK_SERVICES)
         api = MagicMock()
         api.control_service = AsyncMock()
-        ctx = _SwitchContext("test_entry_id", coord, api, MOCK_DEVICE_INFO)
-        entity = OdioServiceSwitch(ctx, svc)
+        entity = OdioServiceSwitch(_make_ctx(coordinator=_make_coordinator(MOCK_SERVICES), api=api), svc)
 
         await entity.async_turn_on()
 
@@ -144,7 +157,7 @@ class TestOdioServiceSwitchActions:
         coord = _make_coordinator(MOCK_SERVICES)
         api = MagicMock()
         api.control_service = AsyncMock()
-        entity = OdioServiceSwitch(_SwitchContext("test_entry_id", coord, api, MOCK_DEVICE_INFO), svc)
+        entity = OdioServiceSwitch(_make_ctx(coordinator=coord, api=api), svc)
 
         await entity.async_turn_on()
 
@@ -153,10 +166,9 @@ class TestOdioServiceSwitchActions:
     @pytest.mark.asyncio
     async def test_turn_off_calls_stop(self):
         svc = MOCK_SERVICES[0]
-        coord = _make_coordinator(MOCK_SERVICES)
         api = MagicMock()
         api.control_service = AsyncMock()
-        entity = OdioServiceSwitch(_SwitchContext("test_entry_id", coord, api, MOCK_DEVICE_INFO), svc)
+        entity = OdioServiceSwitch(_make_ctx(coordinator=_make_coordinator(MOCK_SERVICES), api=api), svc)
 
         await entity.async_turn_off()
 
@@ -169,7 +181,7 @@ class TestOdioServiceSwitchActions:
         coord = _make_coordinator(MOCK_SERVICES)
         api = MagicMock()
         api.control_service = AsyncMock()
-        entity = OdioServiceSwitch(_SwitchContext("test_entry_id", coord, api, MOCK_DEVICE_INFO), svc)
+        entity = OdioServiceSwitch(_make_ctx(coordinator=coord, api=api), svc)
 
         await entity.async_turn_off()
 

--- a/custom_components/odio_remote/translations/en.json
+++ b/custom_components/odio_remote/translations/en.json
@@ -11,16 +11,14 @@
           "api_url": "The base URL of your go-odio-api (e.g. http://192.168.1.100:8018)"
         }
       },
-      "options": {
-        "title": "Scan Settings",
-        "description": "Configure update intervals",
+      "sse": {
+        "title": "SSE Configuration",
+        "description": "Configure the SSE keepalive interval",
         "data": {
-          "scan_interval": "Audio scan interval (seconds)",
-          "service_scan_interval": "Service scan interval (seconds)"
+          "keepalive_interval": "Keepalive interval (seconds)"
         },
         "data_description": {
-          "scan_interval": "How often to update audio clients (recommended: 10s)",
-          "service_scan_interval": "How often to update services (recommended: 60s)"
+          "keepalive_interval": "Server heartbeat interval, 10-120s (recommended: 30s)"
         }
       },
       "zeroconf_confirm": {
@@ -60,20 +58,18 @@
         "title": "Odio Remote Options",
         "description": "What would you like to configure for {name}?",
         "menu_options": {
-          "intervals": "Change scan intervals",
+          "sse": "Configure SSE settings",
           "mappings": "Manage entity mappings"
         }
       },
-      "intervals": {
-        "title": "Scan Intervals",
-        "description": "Configure update intervals",
+      "sse": {
+        "title": "SSE Settings",
+        "description": "Configure the SSE keepalive interval",
         "data": {
-          "scan_interval": "Audio scan interval (seconds)",
-          "service_scan_interval": "Service scan interval (seconds)"
+          "keepalive_interval": "Keepalive interval (seconds)"
         },
         "data_description": {
-          "scan_interval": "How often to update audio clients (recommended: 10s)",
-          "service_scan_interval": "How often to update services (recommended: 60s)"
+          "keepalive_interval": "Server heartbeat interval, 10-120s (recommended: 30s)"
         }
       },
       "mappings": {

--- a/custom_components/odio_remote/translations/fr.json
+++ b/custom_components/odio_remote/translations/fr.json
@@ -11,16 +11,14 @@
           "api_url": "L'URL de base de votre API go-odio-api (ex: http://192.168.1.100:8018)"
         }
       },
-      "options": {
-        "title": "Paramètres de scan",
-        "description": "Configurez les intervalles de mise à jour",
+      "sse": {
+        "title": "Configuration SSE",
+        "description": "Configurez l'intervalle de keepalive SSE",
         "data": {
-          "scan_interval": "Intervalle de scan audio (secondes)",
-          "service_scan_interval": "Intervalle de scan services (secondes)"
+          "keepalive_interval": "Intervalle de keepalive (secondes)"
         },
         "data_description": {
-          "scan_interval": "Fréquence de mise à jour des clients audio (recommandé: 5s)",
-          "service_scan_interval": "Fréquence de mise à jour des services (recommandé: 60s)"
+          "keepalive_interval": "Intervalle de heartbeat serveur, 10-120s (recommandé : 30s)"
         }
       },
       "zeroconf_confirm": {
@@ -60,20 +58,18 @@
         "title": "Options Odio Remote",
         "description": "Que souhaitez-vous configurer pour {name} ?",
         "menu_options": {
-          "intervals": "Modifier les intervalles de scan",
+          "sse": "Configurer les paramètres SSE",
           "mappings": "Gérer les associations d'entités"
         }
       },
-      "intervals": {
-        "title": "Intervalles de scan",
-        "description": "Configurez les intervalles de mise à jour",
+      "sse": {
+        "title": "Paramètres SSE",
+        "description": "Configurez l'intervalle de keepalive SSE",
         "data": {
-          "scan_interval": "Intervalle de scan audio (secondes)",
-          "service_scan_interval": "Intervalle de scan services (secondes)"
+          "keepalive_interval": "Intervalle de keepalive (secondes)"
         },
         "data_description": {
-          "scan_interval": "Fréquence de mise à jour des clients audio (recommandé: 5s)",
-          "service_scan_interval": "Fréquence de mise à jour des services (recommandé: 60s)"
+          "keepalive_interval": "Intervalle de heartbeat serveur, 10-120s (recommandé : 30s)"
         }
       },
       "mappings": {


### PR DESCRIPTION
## Summary
Implement Server-Sent Events (SSE) support to enable real-time updates from the Odio Remote API. This adds a new `OdioEventStreamManager` that maintains a persistent SSE connection and routes events to the appropriate coordinators, replacing the need for periodic polling.

## Key Changes

- **New `OdioEventStreamManager` class** (`event_stream.py`):
  - Manages SSE connection lifecycle with automatic reconnection and exponential backoff
  - Routes `audio.updated` events to the audio coordinator
  - Routes `service.updated` events to the service coordinator with intelligent merging (by name+scope)
  - Handles server control events (`connected`, `love`, `bye`)
  - Implements keepalive timeout detection and graceful shutdown

- **SSE parsing in `OdioApiClient`** (`api_client.py`):
  - New `listen_events()` async generator that opens an SSE connection and yields parsed `SseEvent` objects
  - Handles SSE wire-format parsing (event type, data, blank line termination)
  - Supports filtering by backends and excluding specific event types
  - Gracefully skips events with invalid JSON

- **New `SseEvent` dataclass** (`api_client.py`):
  - Simple container for parsed SSE events with `type` and `data` fields

- **Integration setup** (`__init__.py`):
  - Initialize `OdioEventStreamManager` during setup
  - Start/stop event stream with the integration lifecycle
  - Store event stream manager in runtime data

- **Constants** (`const.py`):
  - Added SSE endpoint and event type constants
  - Added reconnection backoff configuration (1s min, 300s max)

- **Comprehensive test suite** (`tests/test_event_stream.py`):
  - 30+ tests covering SSE parsing, event routing, coordinator updates, and lifecycle management
  - Tests for edge cases: invalid JSON, missing data, empty streams, scope-based service matching

- **Test infrastructure** (`conftest.py`):
  - Root-level conftest with Home Assistant module stubs for unit testing without full HA installation

## Implementation Details

- **Reconnection strategy**: Exponential backoff starting at 1 second, capping at 5 minutes, resets on successful data events
- **Service merging**: Services are identified by (name, scope) tuple; updates replace existing entries or append new ones
- **Graceful degradation**: Manager is optional; integration works without SSE if coordinators aren't available
- **Keepalive handling**: Server sends "love" events periodically; timeout detection ready for future implementation

https://claude.ai/code/session_01JmoSV6xrmat6sXATF5Hwk1