### PR TITLE
feat(audio): handle audio.removed SSE event

### DIFF
--- a/custom_components/odio_remote/__init__.py
+++ b/custom_components/odio_remote/__init__.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_SERVICE_MAPPINGS,
     DEFAULT_KEEPALIVE_INTERVAL,
     DOMAIN,
+    SSE_EVENT_AUDIO_REMOVED,
     SSE_EVENT_AUDIO_UPDATED,
     SSE_EVENT_SERVICE_UPDATED,
 )
@@ -175,6 +176,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: OdioConfigEntry) -> bool
         entry.async_on_unload(
             event_stream.async_add_event_listener(
                 SSE_EVENT_AUDIO_UPDATED, audio_coordinator.handle_sse_event
+            )
+        )
+        entry.async_on_unload(
+            event_stream.async_add_event_listener(
+                SSE_EVENT_AUDIO_REMOVED, audio_coordinator.handle_sse_remove_event
             )
         )
     if service_coordinator is not None:

--- a/custom_components/odio_remote/const.py
+++ b/custom_components/odio_remote/const.py
@@ -33,6 +33,7 @@ ENDPOINT_EVENTS: Final = "/events"
 
 # SSE event types
 SSE_EVENT_AUDIO_UPDATED: Final = "audio.updated"
+SSE_EVENT_AUDIO_REMOVED: Final = "audio.removed"
 SSE_EVENT_SERVICE_UPDATED: Final = "service.updated"
 SSE_EVENT_POWER_ACTION: Final = "power.action"
 SSE_EVENT_SERVER_INFO: Final = "server.info"

--- a/custom_components/odio_remote/coordinator.py
+++ b/custom_components/odio_remote/coordinator.py
@@ -53,14 +53,39 @@ class OdioAudioCoordinator(DataUpdateCoordinator[dict[str, list]]):
             raise UpdateFailed(f"Unexpected error: {err}") from err
 
     def handle_sse_event(self, event: SseEvent) -> None:
-        """Handle an audio.updated SSE event."""
+        """Handle an audio.updated SSE event (changed/added clients only — merge into list)."""
         if not isinstance(event.data, list):
             _LOGGER.warning(
                 "audio.updated: expected list, got %s", type(event.data).__name__
             )
             return
-        _LOGGER.debug("SSE audio.updated: %d clients", len(event.data))
-        self.async_set_updated_data({"audio": event.data})
+        _LOGGER.debug("SSE audio.updated: %d changed/added", len(event.data))
+        current = list((self.data or {}).get("audio", []))
+        updated_by_name = {c["name"]: c for c in event.data if "name" in c}
+        result = [updated_by_name.pop(c.get("name"), c) for c in current]
+        result.extend(updated_by_name.values())
+        self.async_set_updated_data({"audio": result})
+
+    def handle_sse_remove_event(self, event: SseEvent) -> None:
+        """Handle an audio.removed SSE event.
+
+        Keeps removed clients in the list but marks them corked=True so entities
+        transition to Idle instead of disappearing from HA.
+        """
+        if not isinstance(event.data, list):
+            _LOGGER.warning(
+                "audio.removed: expected list, got %s", type(event.data).__name__
+            )
+            return
+        _LOGGER.debug("SSE audio.removed: %d clients", len(event.data))
+        removed_by_name = {
+            c["name"]: {**c, "corked": True}
+            for c in event.data
+            if "name" in c
+        }
+        current = list((self.data or {}).get("audio", []))
+        result = [removed_by_name.get(c.get("name"), c) for c in current]
+        self.async_set_updated_data({"audio": result})
 
 
 class OdioServiceCoordinator(DataUpdateCoordinator[dict[str, Any]]):

--- a/custom_components/odio_remote/manifest.json
+++ b/custom_components/odio_remote/manifest.json
@@ -11,5 +11,5 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/b0bbywan/ha-odio-audio/issues",
   "requirements": ["aiohttp>=3.8.0"],
-  "version": "0.5.0"
+  "version": "0.5.1"
 }

--- a/custom_components/odio_remote/tests/test_coordinator.py
+++ b/custom_components/odio_remote/tests/test_coordinator.py
@@ -127,15 +127,62 @@ class TestOdioServiceCoordinator:
 
 class TestAudioCoordinatorHandleSseEvent:
 
-    def test_valid_list_updates_data(self):
-        """handle_sse_event sets coordinator data when event data is a list."""
+    def _make_coord_with_data(self, clients):
         coord = _make_audio_coordinator(MagicMock())
+        coord.data = {"audio": clients}
+        coord.async_set_updated_data = MagicMock()
+        return coord
+
+    def test_updates_existing_client_by_name(self):
+        """Changed client is replaced in-place by name."""
+        existing = {"id": 1, "name": "Spotify", "volume": 0.5}
+        coord = self._make_coord_with_data([existing])
+
+        updated = {"id": 1, "name": "Spotify", "volume": 0.8}
+        coord.handle_sse_event(SseEvent(type="audio.updated", data=[updated]))
+
+        coord.async_set_updated_data.assert_called_once_with({"audio": [updated]})
+
+    def test_appends_new_client(self):
+        """Unknown client name is appended to the list."""
+        existing = {"id": 1, "name": "Spotify", "volume": 0.5}
+        coord = self._make_coord_with_data([existing])
+
+        new_client = {"id": 2, "name": "VLC", "volume": 1.0}
+        coord.handle_sse_event(SseEvent(type="audio.updated", data=[new_client]))
+
+        coord.async_set_updated_data.assert_called_once_with({"audio": [existing, new_client]})
+
+    def test_unchanged_clients_preserved(self):
+        """Clients not in the event are kept as-is."""
+        a = {"id": 1, "name": "Spotify", "volume": 0.5}
+        b = {"id": 2, "name": "VLC", "volume": 1.0}
+        coord = self._make_coord_with_data([a, b])
+
+        updated_b = {"id": 2, "name": "VLC", "volume": 0.7}
+        coord.handle_sse_event(SseEvent(type="audio.updated", data=[updated_b]))
+
+        coord.async_set_updated_data.assert_called_once_with({"audio": [a, updated_b]})
+
+    def test_empty_event_preserves_existing(self):
+        """Empty event data leaves current list untouched."""
+        existing = [{"id": 1, "name": "Spotify", "volume": 0.5}]
+        coord = self._make_coord_with_data(existing)
+
+        coord.handle_sse_event(SseEvent(type="audio.updated", data=[]))
+
+        coord.async_set_updated_data.assert_called_once_with({"audio": existing})
+
+    def test_works_with_no_existing_data(self):
+        """handle_sse_event handles coordinator.data being None."""
+        coord = _make_audio_coordinator(MagicMock())
+        coord.data = None
         coord.async_set_updated_data = MagicMock()
 
-        event = SseEvent(type="audio.updated", data=[{"id": 1}])
-        coord.handle_sse_event(event)
+        client = {"id": 1, "name": "Spotify", "volume": 0.5}
+        coord.handle_sse_event(SseEvent(type="audio.updated", data=[client]))
 
-        coord.async_set_updated_data.assert_called_once_with({"audio": [{"id": 1}]})
+        coord.async_set_updated_data.assert_called_once_with({"audio": [client]})
 
     def test_non_list_data_ignored(self):
         """handle_sse_event does nothing when event data is not a list."""
@@ -146,12 +193,62 @@ class TestAudioCoordinatorHandleSseEvent:
 
         coord.async_set_updated_data.assert_not_called()
 
-    def test_empty_list_updates_data(self):
-        """handle_sse_event accepts an empty list."""
+
+# ---------------------------------------------------------------------------
+# OdioAudioCoordinator.handle_sse_remove_event
+# ---------------------------------------------------------------------------
+
+
+class TestAudioCoordinatorHandleSseRemoveEvent:
+
+    def _make_coord_with_data(self, clients):
         coord = _make_audio_coordinator(MagicMock())
+        coord.data = {"audio": clients}
+        coord.async_set_updated_data = MagicMock()
+        return coord
+
+    def test_marks_removed_client_as_corked(self):
+        """Removed client stays in list with corked=True → Idle state."""
+        a = {"id": 1, "name": "Spotify", "volume": 0.5, "corked": False}
+        b = {"id": 2, "name": "VLC", "volume": 1.0, "corked": False}
+        coord = self._make_coord_with_data([a, b])
+
+        coord.handle_sse_remove_event(SseEvent(type="audio.removed", data=[a]))
+
+        result = coord.async_set_updated_data.call_args[0][0]["audio"]
+        assert len(result) == 2
+        assert result[0]["name"] == "Spotify"
+        assert result[0]["corked"] is True
+        assert result[1] == b
+
+    def test_unknown_name_ignored(self):
+        """Removing an unknown client does not alter the existing list."""
+        existing = [{"id": 1, "name": "Spotify", "volume": 0.5, "corked": False}]
+        coord = self._make_coord_with_data(existing)
+
+        coord.handle_sse_remove_event(
+            SseEvent(type="audio.removed", data=[{"id": 99, "name": "Ghost"}])
+        )
+
+        coord.async_set_updated_data.assert_called_once_with({"audio": existing})
+
+    def test_non_list_data_ignored(self):
+        """handle_sse_remove_event does nothing when event data is not a list."""
+        coord = self._make_coord_with_data([])
+
+        coord.handle_sse_remove_event(SseEvent(type="audio.removed", data={"not": "a list"}))
+
+        coord.async_set_updated_data.assert_not_called()
+
+    def test_works_with_no_existing_data(self):
+        """handle_sse_remove_event handles coordinator.data being None."""
+        coord = _make_audio_coordinator(MagicMock())
+        coord.data = None
         coord.async_set_updated_data = MagicMock()
 
-        coord.handle_sse_event(SseEvent(type="audio.updated", data=[]))
+        coord.handle_sse_remove_event(
+            SseEvent(type="audio.removed", data=[{"id": 1, "name": "Spotify"}])
+        )
 
         coord.async_set_updated_data.assert_called_once_with({"audio": []})
 


### PR DESCRIPTION
audio.updated now carries only changed/added clients — merge into existing list instead of replacing. audio.removed marks clients as corked=True (Idle) rather than dropping them, so HA entities stay registered and transition to Idle state.