### PR TITLE
fix: mark MPRIS players unavailable when SSE disconnects

### DIFF
--- a/custom_components/odio_remote/media_player.py
+++ b/custom_components/odio_remote/media_player.py
@@ -846,7 +846,7 @@ class OdioMPRISMediaPlayer(MappedEntityMixin, CoordinatorEntity, MediaPlayerEnti
     def available(self) -> bool:
         """Return True if the player is reported by the coordinator and not removed."""
         player = self._player_data
-        return self.coordinator.last_update_success and player is not None and player.get("available", True)
+        return self._event_stream.sse_connected and self.coordinator.last_update_success and player is not None and player.get("available", True)
 
     @property
     def _player_data(self) -> dict[str, Any] | None:

--- a/custom_components/odio_remote/tests/test_mpris.py
+++ b/custom_components/odio_remote/tests/test_mpris.py
@@ -367,6 +367,11 @@ class TestMPRISEntityProperties:
         entity = _make_entity(MOCK_SPOTIFY, last_update_success=False)
         assert entity.available is False
 
+    def test_available_false_when_sse_disconnected(self):
+        entity = _make_entity(MOCK_SPOTIFY)
+        entity._event_stream.sse_connected = False
+        assert entity.available is False
+
     def test_media_position_converts_us_to_seconds(self):
         """28962000 µs → 28 seconds."""
         entity = _make_entity({**MOCK_SPOTIFY, "position": 28962000})


### PR DESCRIPTION
OdioMPRISMediaPlayer.available was missing the sse_connected check, causing entities to retain their last known state (e.g. Playing) when the Odio instance shuts down.