### PR TITLE
fix: refresh mapped entity wrappers on source state changes

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-# Ignore les erreurs de longueur de ligne
-ignore = E501,W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,9 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
 
-    - name: Lint with flake8
+    - name: Lint with ruff
       run: |
-        flake8 .
+        ruff check .
 
     - name: Type check with mypy
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ github.event.workflow_run.head_sha }}
         fetch-depth: 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ pytest custom_components/odio_remote/tests/test_api_client.py -v
 pytest custom_components/odio_remote/tests/test_config_flow.py::TestConfigFlowUser::test_show_form_no_input -v
 
 # Linting
-flake8 custom_components/odio_remote/
+ruff check custom_components/odio_remote/
 
 # Type checking
 mypy custom_components/odio_remote/

--- a/custom_components/odio_remote/__init__.py
+++ b/custom_components/odio_remote/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceEntry
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 
 from .api_client import OdioApiClient
 from .event_stream import OdioEventStreamManager

--- a/custom_components/odio_remote/binary_sensor.py
+++ b/custom_components/odio_remote/binary_sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from homeassistant.helpers.update_coordinator import CoordinatorEntity

--- a/custom_components/odio_remote/button.py
+++ b/custom_components/odio_remote/button.py
@@ -5,7 +5,7 @@ import logging
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import OdioConfigEntry

--- a/custom_components/odio_remote/coordinator.py
+++ b/custom_components/odio_remote/coordinator.py
@@ -181,8 +181,14 @@ class OdioMPRISCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Fetch MPRIS status from API."""
         try:
             players, cache_ts = await self.api.get_players()
-            position_updated_at = dt_util.parse_datetime(cache_ts) if cache_ts else dt_util.utcnow()
-            stamped = [{**p, "position_updated_at": position_updated_at} for p in players]
+            fallback_ts = dt_util.parse_datetime(cache_ts) if cache_ts else None
+            if fallback_ts is None:
+                fallback_ts = dt_util.utcnow()
+            stamped = []
+            for p in players:
+                raw = p.get("position_updated_at")
+                ts = dt_util.parse_datetime(raw) if isinstance(raw, str) else None
+                stamped.append({**p, "position_updated_at": ts or fallback_ts})
             return {"mpris": stamped}
         except (OdioConnectionError, OdioTimeoutError) as err:
             raise UpdateFailed(f"Unable to connect to Odio Remote API: {err}") from err
@@ -195,10 +201,16 @@ class OdioMPRISCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         bus_name = player_data.get("bus_name")
         if not bus_name:
             return
-        if emitted_at_ms is not None:
-            ts = dt_util.utc_from_timestamp(emitted_at_ms / 1000)
-        else:
-            ts = dt_util.utcnow()
+        # Prefer the per-player position_updated_at from the backend; fall back
+        # to the SSE wrapper's emitted_at, which can be newer than the actual
+        # position write (e.g. a player.updated triggered by a Volume change).
+        raw_pos_ts = player_data.get("position_updated_at")
+        ts = dt_util.parse_datetime(raw_pos_ts) if isinstance(raw_pos_ts, str) else None
+        if ts is None:
+            if emitted_at_ms is not None:
+                ts = dt_util.utc_from_timestamp(emitted_at_ms / 1000)
+            else:
+                ts = dt_util.utcnow()
         stamped = {**player_data, "position_updated_at": ts}
         current = list((self.data or {}).get("mpris", []))
         for i, p in enumerate(current):

--- a/custom_components/odio_remote/helpers.py
+++ b/custom_components/odio_remote/helpers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import logging
 import socket
 from functools import wraps
+from typing import Any, Callable, Coroutine, ParamSpec, TypeVar
 
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -11,6 +12,9 @@ from homeassistant.exceptions import HomeAssistantError
 from .exceptions import OdioApiError, OdioConnectionError, OdioTimeoutError
 
 _LOGGER = logging.getLogger(__name__)
+
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
 
 
 async def async_get_mac_from_ip(hass: HomeAssistant, ip: str) -> str | None:
@@ -45,7 +49,9 @@ async def async_get_mac_from_ip(hass: HomeAssistant, ip: str) -> str | None:
     return None
 
 
-def api_command(func):
+def api_command(
+    func: Callable[_P, Coroutine[Any, Any, _R]],
+) -> Callable[_P, Coroutine[Any, Any, _R]]:
     """Decorate an async entity action that calls the Odio API.
 
     Acts as the boundary between the Odio domain and Home Assistant:
@@ -57,7 +63,7 @@ def api_command(func):
     """
 
     @wraps(func)
-    async def wrapper(*args, **kwargs):
+    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> _R:
         try:
             return await func(*args, **kwargs)
         except HomeAssistantError:

--- a/custom_components/odio_remote/manifest.json
+++ b/custom_components/odio_remote/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "device",
   "issue_tracker": "https://github.com/b0bbywan/odio-ha/issues",
   "quality_scale": "silver",
-  "version": "0.9.1-rc.1"
+  "version": "0.9.1"
 }

--- a/custom_components/odio_remote/manifest.json
+++ b/custom_components/odio_remote/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "device",
   "issue_tracker": "https://github.com/b0bbywan/odio-ha/issues",
   "quality_scale": "silver",
-  "version": "0.9.0"
+  "version": "0.9.1-rc.1"
 }

--- a/custom_components/odio_remote/media_player.py
+++ b/custom_components/odio_remote/media_player.py
@@ -16,7 +16,7 @@ from homeassistant.components.media_player import (
     RepeatMode,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/odio_remote/mixins.py
+++ b/custom_components/odio_remote/mixins.py
@@ -10,24 +10,24 @@ from homeassistant.components.media_player import (
     RepeatMode,
 )
 from homeassistant.core import callback
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import async_track_state_change_event
 
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class MappedEntityMixin:
+class MappedEntityMixin(Entity):
     """Mixin for entities that can delegate to mapped entities.
 
     Expects to be used alongside CoordinatorEntity, which provides
-    self.coordinator and self.hass.
+    self.coordinator.
 
     Subclasses must implement:
     - _mapping_key property: returns the key for looking up mappings
     """
 
     coordinator: Any
-    hass: Any
 
     async def async_added_to_hass(self) -> None:
         """Track state changes of the mapped entity.
@@ -37,10 +37,10 @@ class MappedEntityMixin:
         Under SSE that happens rarely, so the wrapper would appear frozen
         whenever the underlying player's state changed independently.
         """
-        await super().async_added_to_hass()  # type: ignore[misc]
+        await super().async_added_to_hass()
         mapped = self._mapped_entity
         if mapped:
-            self.async_on_remove(  # type: ignore[attr-defined]
+            self.async_on_remove(
                 async_track_state_change_event(
                     self.hass, [mapped], self._handle_mapped_state_change
                 )
@@ -49,7 +49,7 @@ class MappedEntityMixin:
     @callback
     def _handle_mapped_state_change(self, event) -> None:
         """Refresh this entity when the mapped entity's state changes."""
-        self.async_write_ha_state()  # type: ignore[attr-defined]
+        self.async_write_ha_state()
 
     @property
     def _mapping_key(self) -> str:

--- a/custom_components/odio_remote/mixins.py
+++ b/custom_components/odio_remote/mixins.py
@@ -9,6 +9,8 @@ from homeassistant.components.media_player import (
     MediaPlayerState,
     RepeatMode,
 )
+from homeassistant.core import callback
+from homeassistant.helpers.event import async_track_state_change_event
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -26,6 +28,28 @@ class MappedEntityMixin:
 
     coordinator: Any
     hass: Any
+
+    async def async_added_to_hass(self) -> None:
+        """Track state changes of the mapped entity.
+
+        Without this, properties delegated to the mapped entity (media_title,
+        position, etc.) only refresh when our own coordinator pushes an update.
+        Under SSE that happens rarely, so the wrapper would appear frozen
+        whenever the underlying player's state changed independently.
+        """
+        await super().async_added_to_hass()  # type: ignore[misc]
+        mapped = self._mapped_entity
+        if mapped:
+            self.async_on_remove(  # type: ignore[attr-defined]
+                async_track_state_change_event(
+                    self.hass, [mapped], self._handle_mapped_state_change
+                )
+            )
+
+    @callback
+    def _handle_mapped_state_change(self, event) -> None:
+        """Refresh this entity when the mapped entity's state changes."""
+        self.async_write_ha_state()  # type: ignore[attr-defined]
 
     @property
     def _mapping_key(self) -> str:

--- a/custom_components/odio_remote/sensor.py
+++ b/custom_components/odio_remote/sensor.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/odio_remote/switch.py
+++ b/custom_components/odio_remote/switch.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 

--- a/custom_components/odio_remote/tests/conftest.py
+++ b/custom_components/odio_remote/tests/conftest.py
@@ -278,6 +278,7 @@ MOCK_PLAYERS = [
         "shuffle": True,
         "volume": 0.8,
         "position": 28962000,
+        "position_updated_at": "2026-03-04T19:06:00Z",
         "rate": 1,
         "metadata": {
             "mpris:artUrl": "https://i.scdn.co/image/abc123",
@@ -302,6 +303,7 @@ MOCK_PLAYERS = [
         "playback_status": "Paused",
         "volume": 1.0,
         "position": 987200000,
+        "position_updated_at": "2026-03-04T19:06:00Z",
         "metadata": {
             "mpris:artUrl": "file:///tmp/.com.google.Chrome.abc",
             "mpris:length": "987200000",

--- a/custom_components/odio_remote/tests/test_mpris.py
+++ b/custom_components/odio_remote/tests/test_mpris.py
@@ -88,10 +88,24 @@ def _make_entity(player_data, extra_players=None, mappings=None, last_update_suc
 class TestMPRISCoordinatorFetch:
 
     @pytest.mark.asyncio
-    async def test_stamps_position_updated_at_from_header(self):
-        """x-cache-updated-at header is parsed and stamped on each player."""
+    async def test_uses_per_player_position_updated_at_when_present(self):
+        """Per-player position_updated_at takes precedence over the cache header."""
+        player = {**MOCK_SPOTIFY, "position_updated_at": "2027-09-12T08:30:00Z"}
         api = MagicMock()
-        api.get_players = AsyncMock(return_value=([MOCK_SPOTIFY], "2026-03-04T19:06:44Z"))
+        api.get_players = AsyncMock(return_value=([player], "2026-03-04T19:06:44Z"))
+        coord = OdioMPRISCoordinator(_make_hass(), MagicMock(), api)
+
+        result = await coord._async_update_data()
+
+        ts = result["mpris"][0]["position_updated_at"]
+        assert ts.year == 2027
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_header_when_no_per_player_field(self):
+        """x-cache-updated-at header is used when player has no per-player field."""
+        legacy_player = {k: v for k, v in MOCK_SPOTIFY.items() if k != "position_updated_at"}
+        api = MagicMock()
+        api.get_players = AsyncMock(return_value=([legacy_player], "2025-01-01T00:00:00Z"))
         coord = OdioMPRISCoordinator(_make_hass(), MagicMock(), api)
 
         result = await coord._async_update_data()
@@ -101,13 +115,14 @@ class TestMPRISCoordinatorFetch:
         ts = players[0]["position_updated_at"]
         assert ts is not None
         assert ts.tzinfo is not None
-        assert ts.year == 2026
+        assert ts.year == 2025
 
     @pytest.mark.asyncio
     async def test_falls_back_to_utcnow_when_no_header(self):
         """position_updated_at falls back to utcnow when header is absent."""
+        legacy_player = {k: v for k, v in MOCK_SPOTIFY.items() if k != "position_updated_at"}
         api = MagicMock()
-        api.get_players = AsyncMock(return_value=([MOCK_SPOTIFY], None))
+        api.get_players = AsyncMock(return_value=([legacy_player], None))
         coord = OdioMPRISCoordinator(_make_hass(), MagicMock(), api)
 
         result = await coord._async_update_data()
@@ -178,9 +193,19 @@ class TestMPRISCoordinatorSseUpdate:
         result = coord.async_set_updated_data.call_args[0][0]["mpris"]
         assert len(result) == 2
 
-    def test_stamps_position_updated_at_from_emitted_at(self):
+    def test_uses_per_player_position_updated_at_over_emitted_at(self):
+        """Per-player position_updated_at wins over the SSE wrapper's emitted_at."""
         coord = self._coord_with_players([])
-        coord.handle_sse_update_event(self._sse_event(MOCK_SPOTIFY, emitted_at=EMITTED_AT_MS))
+        player = {**MOCK_SPOTIFY, "position_updated_at": "2027-09-12T08:30:00Z"}
+        coord.handle_sse_update_event(self._sse_event(player, emitted_at=EMITTED_AT_MS))
+
+        result = coord.async_set_updated_data.call_args[0][0]["mpris"]
+        assert result[0]["position_updated_at"].year == 2027
+
+    def test_stamps_position_updated_at_from_emitted_at_when_field_absent(self):
+        coord = self._coord_with_players([])
+        legacy_player = {k: v for k, v in MOCK_SPOTIFY.items() if k != "position_updated_at"}
+        coord.handle_sse_update_event(self._sse_event(legacy_player, emitted_at=EMITTED_AT_MS))
 
         result = coord.async_set_updated_data.call_args[0][0]["mpris"]
         expected_ts = datetime.fromtimestamp(EMITTED_AT_MS / 1000, tz=timezone.utc)
@@ -221,9 +246,10 @@ class TestMPRISCoordinatorSseUpdate:
         coord.async_set_updated_data.assert_not_called()
 
     def test_emitted_at_none_falls_back_to_utcnow(self):
-        """_merge_player uses utcnow() when emitted_at_ms is None."""
+        """_merge_player uses utcnow() when both per-player field and emitted_at are missing."""
         coord = self._coord_with_players([])
-        coord.handle_sse_update_event(self._sse_event(MOCK_SPOTIFY, emitted_at=None))
+        legacy_player = {k: v for k, v in MOCK_SPOTIFY.items() if k != "position_updated_at"}
+        coord.handle_sse_update_event(self._sse_event(legacy_player, emitted_at=None))
         result = coord.async_set_updated_data.call_args[0][0]["mpris"]
         assert result[0]["position_updated_at"] is not None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.ruff]
+line-length = 120

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 homeassistant==2026.1.3
 mypy==1.19.1
 mypy_extensions==1.1.0
-flake8==7.3.0
+ruff==0.15.12
 pytest==9.0.2
 pytest-asyncio==1.3.0
 pytest-cov==7.0.0


### PR DESCRIPTION
Under SSE, our coordinators no longer poll periodically, so wrapper entities froze whenever the mapped media_player changed state on its own. Subscribe to state_changed events for the mapped entity so delegated properties (title, position, volume…) re-render in HA.