### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/b0bbywan/odio-ha/security/code-scanning/1](https://github.com/b0bbywan/odio-ha/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root so it applies to all jobs (including `lint-test`) unless overridden.  
For this workflow, the best minimal setting is:

- `contents: read`

This is sufficient for `actions/checkout` and the read-only CI tasks shown (lint/type-check/test). No imports, methods, or additional definitions are needed—just a YAML key insertion near the top-level keys.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
