### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 6 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   hacs:
     name: HACS


### PR DESCRIPTION
Potential fix for [https://github.com/b0bbywan/odio-ha/security/code-scanning/2](https://github.com/b0bbywan/odio-ha/security/code-scanning/2)

Add an explicit top-level `permissions` block to `.github/workflows/validate.yml` so all jobs inherit least-privilege token access by default.  
Best single fix without changing functionality: define workflow-level permissions with `contents: read`, which is the minimal baseline and matches CodeQL guidance for this case.

**File/region to change**
- `.github/workflows/validate.yml`
- Insert `permissions:` after the trigger section (`on:` block) and before `jobs:`.

**What is needed**
- No imports, methods, or dependencies.
- One YAML block addition:
  - `permissions:`
  - `contents: read`


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
